### PR TITLE
Changes the type for the user_data field

### DIFF
--- a/migrations/20180712131745-change-user-data-type.js
+++ b/migrations/20180712131745-change-user-data-type.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20180712131745-change-user-data-type-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20180712131745-change-user-data-type-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20180712131745-change-user-data-type-down.sql
+++ b/migrations/sqls/20180712131745-change-user-data-type-down.sql
@@ -1,0 +1,51 @@
+-- delete the view
+drop view if exists "idm"."kpi_view";
+
+-- now the type of user_data on the users table can be updated
+alter table idm.users
+alter column user_data type varchar;
+
+-- now the view can be recreated
+CREATE VIEW "idm"."kpi_view" AS
+ SELECT (x.usertype || '_registrations_completed'::text) AS datapoint,
+    count(*) AS value,
+    (('Registrations completed post public beta for '::text || x.usertype) || ' users'::text) AS description
+   FROM ( SELECT
+                CASE
+                    WHEN ((to_jsonb((users.user_data)::json) ->> 'usertype'::text) IS NOT NULL) THEN (to_jsonb((users.user_data)::json) ->> 'usertype'::text)
+                    ELSE 'external'::text
+                END AS usertype
+           FROM idm.users
+          WHERE ((users.last_login IS NOT NULL) AND (users.user_id > 113))) x
+  GROUP BY (x.usertype || '_registrations_completed'::text), x.usertype
+UNION
+ SELECT (x.usertype || '_registrations_not_completed'::text) AS datapoint,
+    count(*) AS value,
+    (('Registrations started post public beta but not completed for '::text || x.usertype) || ' users'::text) AS description
+   FROM ( SELECT
+                CASE
+                    WHEN ((to_jsonb((users.user_data)::json) ->> 'usertype'::text) IS NOT NULL) THEN (to_jsonb((users.user_data)::json) ->> 'usertype'::text)
+                    ELSE 'external'::text
+                END AS usertype
+           FROM idm.users
+          WHERE ((users.last_login IS NULL) AND (users.user_id > 113))) x
+  GROUP BY (x.usertype || '_registrations_not_completed'::text), x.usertype
+UNION
+ SELECT (x.usertype || '_user_accounts'::text) AS datapoint,
+    count(*) AS value,
+    (('Total '::text || x.usertype) || '  post public beta user accounts'::text) AS description
+   FROM ( SELECT
+                CASE
+                    WHEN ((to_jsonb((users.user_data)::json) ->> 'usertype'::text) IS NOT NULL) THEN (to_jsonb((users.user_data)::json) ->> 'usertype'::text)
+                    ELSE 'external'::text
+                END AS usertype
+           FROM idm.users
+          WHERE (users.user_id > 113)) x
+  GROUP BY (x.usertype || '_user_accounts'::text), x.usertype
+UNION
+ SELECT 'total_user_accounts'::text AS datapoint,
+    count(*) AS value,
+    'Total post public beta user accounts'::text AS description
+   FROM idm.users
+  WHERE (users.user_id > 113)
+  GROUP BY 'total_user_accounts'::text

--- a/migrations/sqls/20180712131745-change-user-data-type-up.sql
+++ b/migrations/sqls/20180712131745-change-user-data-type-up.sql
@@ -1,0 +1,39 @@
+-- delete the view
+drop view if exists "idm"."kpi_view";
+
+-- now the type of user_data on the users table can be updated
+alter table idm.users
+alter column user_data type jsonb using user_data::jsonb;
+
+-- now the view can be recreated
+create view "idm"."kpi_view" as  
+select
+	'registrations_completed' as datapoint,
+	usertype as "dimension",
+	count(*) as "measure" from (
+		select
+			case WHEN user_data->>'usertype' is not null then user_data->>'usertype'
+				else 'external'
+			end as usertype
+		from idm.users
+		where last_login is not null
+		and user_id > 113
+
+) x 	group by datapoint,dimension
+
+union
+
+--    How many users have started registration but not completed it?
+select
+	'registrations_not_completed'  as datapoint,
+	usertype as "dimension",
+	count(*) as "measure" from (
+		select
+			case WHEN user_data->>'usertype' is not null then user_data->>'usertype'
+				else 'external'
+			end as usertype
+		from idm.users
+		where last_login is null
+		and user_id > 113
+
+) x group by datapoint,dimension


### PR DESCRIPTION
WATER-1125

Updates the `idm.users.user_data field` to have a data type of `jsonb`.

To do so, the `kpi_view` view has to be dropped and recreated targeting
the new data type.