### PR TITLE
feature: Use application when authenticating

### DIFF
--- a/.labrc.js
+++ b/.labrc.js
@@ -1,0 +1,14 @@
+// default settings for lab test runs.
+//
+// This is overridden if arguments are passed to lab via the command line.
+module.exports = {
+  // This version global seems to be introduced by sinon.
+  globals: 'version',
+  'coverage-exclude': [
+    'src/lib/logger/vendor',
+    'scripts',
+    'node_modules',
+    'migrations',
+    'test'
+  ]
+};

--- a/migrations/20180720134957-set-user-application-and-remove-admin.js
+++ b/migrations/20180720134957-set-user-application-and-remove-admin.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20180720134957-set-user-application-and-remove-admin-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20180720134957-set-user-application-and-remove-admin-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20180720134957-set-user-application-and-remove-admin-down.sql
+++ b/migrations/sqls/20180720134957-set-user-application-and-remove-admin-down.sql
@@ -1,0 +1,6 @@
+alter table idm.users
+  add column admin bigint;
+
+update idm.users
+set admin = 1
+where application = 'water_admin';

--- a/migrations/sqls/20180720134957-set-user-application-and-remove-admin-up.sql
+++ b/migrations/sqls/20180720134957-set-user-application-and-remove-admin-up.sql
@@ -1,0 +1,13 @@
+update idm.users
+set application = 'water_admin',
+  date_updated = now()
+where admin = 1;
+
+update idm.users
+set application = 'water_vml',
+  date_updated = now()
+where application is null;
+
+alter table idm.users
+  drop column admin;
+

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "heroku-prebuild": "npm install --only=dev",
     "heroku-postbuild": "gulp clean && gulp copy-govuk-files && gulp install-govuk-files && gulp copy-static-assets && gulp sass",
-    "test": "./node_modules/lab/bin/lab -t 55 -m 0 --coverage-path ./src/ --ignore r -r lcov -o lcov.info -r console -o stdout",
+    "test": "./node_modules/lab/bin/lab -t 55 -m 0 --ignore r -r lcov -o lcov.info -r console -o stdout",
     "test-cov-html": "lab -r html -o coverage.html",
     "migrate": "node scripts/create-schema && node node_modules/db-migrate/bin/db-migrate up --verbose",
     "migrate:down": "db-migrate down --verbose",

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -38,7 +38,6 @@ module.exports = (config = {}) => {
       user_id: [Joi.number().required(), Joi.string().email().required().lowercase()],
       user_name: Joi.string().email().trim().lowercase(),
       password: Joi.string(),
-      admin: Joi.number(),
       user_data: Joi.object(),
       reset_guid: Joi.string().guid().allow(null),
       reset_required: Joi.number(),

--- a/src/routes/idm.js
+++ b/src/routes/idm.js
@@ -44,25 +44,12 @@ module.exports = [
     path: '/idm/' + version + '/user/login',
     handler: IDM.loginUser,
     options: {
-      description: 'Login for non-admin users, responds with user details',
+      description: 'Login users, responds with user details',
       validate: {
         payload: {
           user_name: Joi.string().required(),
-          password: Joi.string().required()
-        }
-      }
-    }
-  },
-  {
-    method: 'POST',
-    path: '/idm/' + version + '/user/loginAdmin',
-    handler: IDM.loginAdminUser,
-    options: {
-      description: 'Login for admin users, responds with user details',
-      validate: {
-        payload: {
-          user_name: Joi.string().required(),
-          password: Joi.string().required()
+          password: Joi.string().required(),
+          application: Joi.string().required()
         }
       }
     }

--- a/test/users.js
+++ b/test/users.js
@@ -60,7 +60,9 @@ lab.experiment('Test users API', () => {
     context.userId = payload.data.user_id;
   });
 
-  lab.after(deleteTestUsers);
+  lab.after(async () => {
+    await deleteTestUsers();
+  });
 
   lab.test('The API should create a user', async ({ context }) => {
     const res = await createTestUser(testEmailTwo);


### PR DESCRIPTION
Removes the user of the `admin` flag and replaces with the use of the
`application` field.

All requests go through `/login` now with the `application` value passed
in the body.

This is a breaking change for the two applicaitons that log in. There are PRs for updating both projects:

- [VML](https://github.com/DEFRA/water-abstraction-ui/pull/354)
- [Admin](https://github.com/DEFRA/water-abstraction-admin-ui/pull/59)