### PR TITLE
Fix: WATER-1415 bad logins count

### DIFF
--- a/src/lib/idm.js
+++ b/src/lib/idm.js
@@ -158,7 +158,7 @@ async function doUserLogin (userName, password, application) {
 }
 
 function increaseLockCount (user) {
-  const badLogins = parseInt(get(user, 'badLogins', 0));
+  const badLogins = parseInt(get(user, 'bad_logins', 0));
   const loginCount = isFinite(badLogins) ? badLogins + 1 : 1;
 
   if (loginCount === 10) {

--- a/test/auth.js
+++ b/test/auth.js
@@ -150,9 +150,10 @@ lab.experiment('Test authentication API', () => {
   lab.test('bad_logins is incremented on failed auth attempt', async ({ context }) => {
     const request = buildRequest(context.email, 'wrongpass', context.application);
     await server.inject(request);
+    await server.inject(request);
 
     const user = await getUser(context.userId);
-    expect(user.bad_logins).to.equal('1');
+    expect(user.bad_logins).to.equal('2');
   });
 
   lab.test('A user cannot use credentials for a different application', async({ context }) => {


### PR DESCRIPTION
Corrects a refactoring error so sets bad_logins correctly

Alters test to prevent regression.