### PR TITLE
 Fix: Correct reset password URL for internal users

### DIFF
--- a/config.js
+++ b/config.js
@@ -35,5 +35,10 @@ module.exports = {
 
   services: {
     water: process.env.WATER_URI || 'http://127.0.0.1:8001/water/1.0'
+  },
+
+  application: {
+    water_vml: process.env.BASE_URL || 'http://127.0.0.1:8000',
+    water_admin: process.env.ADMIN_BASE_URL || 'http://127.0.0.1:8008'
   }
 };

--- a/src/controllers/reset.js
+++ b/src/controllers/reset.js
@@ -54,7 +54,8 @@ const sendPasswordResetEmail = async (user, resetGuid, sender, mode) => {
     email: user.user_name,
     firstName: get(user, 'user_data.firstName', '(User)'),
     resetGuid,
-    sender
+    sender,
+    userApplication: user.application
   }, mode);
 
   if (err) {

--- a/src/lib/connectors/notify.js
+++ b/src/lib/connectors/notify.js
@@ -1,8 +1,9 @@
 const Water = require('./water');
 const { logger } = require('../../logger');
+const { application } = require('../../../config');
 
-const getPasswordResetUrl = resetGuid => {
-  return `${process.env.BASE_URL}/reset_password_change_password?resetGuid=${resetGuid}`;
+const getPasswordResetUrl = (resetGuid, userApplication) => {
+  return `${application[userApplication]}/reset_password_change_password?resetGuid=${resetGuid}`;
 };
 
 /**
@@ -55,10 +56,10 @@ function mapNotifyPersonalisation (params, mode) {
  * @
  */
 function sendPasswordResetEmail (params, mode = 'reset') {
-  const { email, resetGuid, firstName, sender } = params;
+  const { email, resetGuid, firstName, sender, userApplication } = params;
   const personalisation = {
     firstName,
-    resetUrl: getPasswordResetUrl(resetGuid),
+    resetUrl: getPasswordResetUrl(resetGuid, userApplication),
     createUrl: `${process.env.BASE_URL}/create-password?resetGuid=${resetGuid}&utm_source=system&utm_medium=email&utm_campaign=create_password`,
     shareUrl: `${process.env.BASE_URL}/create-password?resetGuid=${resetGuid}&utm_source=system&utm_medium=email&utm_campaign=share_access`,
     loginUrl: `${process.env.BASE_URL}/signin?utm_source=system&utm_medium=email&utm_campaign=send_login`,

--- a/src/lib/connectors/notify.js
+++ b/src/lib/connectors/notify.js
@@ -80,7 +80,7 @@ function sendPasswordLockEmail (params) {
 
     const personalisation = {
       reset_url: getPasswordResetUrl(params.resetGuid, params.userApplication),
-      firstname: params.firstname
+      firstname: params.firstName
     };
 
     const emailAddress = params.email;

--- a/src/lib/connectors/notify.js
+++ b/src/lib/connectors/notify.js
@@ -79,7 +79,7 @@ function sendPasswordLockEmail (params) {
     logger.info(params);
 
     const personalisation = {
-      reset_url: getPasswordResetUrl(params.resetGuid),
+      reset_url: getPasswordResetUrl(params.resetGuid, params.userApplication),
       firstname: params.firstname
     };
 

--- a/src/lib/idm.js
+++ b/src/lib/idm.js
@@ -74,7 +74,8 @@ function increaseLockCount (user) {
       Notify.sendPasswordLockEmail({
         email: user.user_name,
         firstname: get(user, 'user_data.firstname', 'User'),
-        resetGuid
+        resetGuid,
+        userApplication: user.application
       })
     ];
 

--- a/test/config.js
+++ b/test/config.js
@@ -24,6 +24,14 @@ experiment('config.js', () => {
     test('logging level is "info"', async () => {
       expect(config.logger.level).to.equal('info');
     });
+
+    test('default application base url for external service', async () => {
+      expect(config.application.water_vml).to.equal('http://127.0.0.1:8000');
+    });
+
+    test('default application base url for internal service', async () => {
+      expect(config.application.water_admin).to.equal('http://127.0.0.1:8008');
+    });
   });
 
   experiment('when test mode is disabled', () => {

--- a/test/lib/connectors/notify.js
+++ b/test/lib/connectors/notify.js
@@ -1,0 +1,99 @@
+const { expect } = require('@hapi/code');
+const { beforeEach, afterEach, experiment, test } = exports.lab = require('@hapi/lab').script();
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+const helpers = require('@envage/water-abstraction-helpers');
+
+const config = require('../../../config');
+const notify = require('../../../src/lib/connectors/notify');
+const { logger } = require('../../../src/logger');
+
+const response = { foo: 'bar' };
+const params = {
+  email: 'bob@example.com',
+  resetGuid: '123-abc',
+  firstName: 'bob',
+  sender: 'test-sender',
+  userApplication: 'water_vml'
+};
+const token = 'token';
+
+experiment('notify connectors', () => {
+  let jwtToken;
+
+  beforeEach(async () => {
+    sandbox.stub(helpers.serviceRequest, 'post').resolves(response);
+    sandbox.stub(logger, 'error');
+    jwtToken = process.env.JWT_TOKEN;
+    process.env.JWT_TOKEN = token;
+  });
+
+  afterEach(async () => {
+    process.env.JWT_TOKEN = jwtToken;
+    sandbox.restore();
+  });
+
+  experiment('sendNotifyMessage', () => {
+    test('calls serviceRequest.post with correct arguments', async () => {
+      await notify.sendPasswordResetEmail(params);
+      const [uri, options] = helpers.serviceRequest.post.lastCall.args;
+      expect(uri).to.equal(`${config.services.water}/notify/password_reset_email`);
+      expect(options).to.equal({
+        body: { recipient: params.email,
+          personalisation: {
+            firstname: params.firstName,
+            reset_url: `http://127.0.0.1:8000/reset_password_change_password?resetGuid=${params.resetGuid}`
+          }
+        } });
+    });
+
+    test('resolves with the response from the POST request', async () => {
+      const data = await notify.sendPasswordResetEmail(params);
+      expect(data).to.equal(response);
+    });
+
+    experiment('when the POST fails', () => {
+      beforeEach(async () => {
+        helpers.serviceRequest.post.rejects();
+      });
+
+      test('throws and logs an error', async () => {
+        const func = () => notify.sendPasswordResetEmail(params);
+        await expect(func()).to.reject();
+        expect(logger.error.callCount).to.equal(1);
+      });
+    });
+  });
+
+  experiment('sendPasswordLockEmail', () => {
+    test('calls serviceRequest.post with correct arguments', async () => {
+      await notify.sendPasswordLockEmail(params);
+      const [uri, options] = helpers.serviceRequest.post.lastCall.args;
+      expect(uri).to.equal(`${config.services.water}/notify/password_locked_email`);
+      expect(options).to.equal({
+        body: { recipient: params.email,
+          personalisation: {
+            firstname: params.firstName,
+            reset_url: `http://127.0.0.1:8000/reset_password_change_password?resetGuid=${params.resetGuid}`
+          }
+        } });
+    });
+
+    test('resolves with the response from the POST request', async () => {
+      const data = await notify.sendPasswordLockEmail(params);
+      expect(data).to.be.true();
+    });
+
+    experiment('when the POST fails', () => {
+      beforeEach(async () => {
+        helpers.serviceRequest.post.rejects();
+      });
+
+      test('throws and logs an error', async () => {
+        const func = () => notify.sendPasswordLockEmail(params);
+        await expect(func()).to.reject();
+        expect(logger.error.callCount).to.equal(3);
+      });
+    });
+  });
+});

--- a/test/lib/connectors/notify.js
+++ b/test/lib/connectors/notify.js
@@ -16,20 +16,14 @@ const params = {
   sender: 'test-sender',
   userApplication: 'water_vml'
 };
-const token = 'token';
 
 experiment('notify connectors', () => {
-  let jwtToken;
-
   beforeEach(async () => {
     sandbox.stub(helpers.serviceRequest, 'post').resolves(response);
     sandbox.stub(logger, 'error');
-    jwtToken = process.env.JWT_TOKEN;
-    process.env.JWT_TOKEN = token;
   });
 
   afterEach(async () => {
-    process.env.JWT_TOKEN = jwtToken;
     sandbox.restore();
   });
 


### PR DESCRIPTION
WATER-2172

Set up config variables for base url based on application. 
Update sendPasswordLockEmail method to use new reset password url.
Create test file for notify connector.