### PR TITLE
Feat/water 2204 migrate roles

### DIFF
--- a/migrations/20190729144004-user-groups.js
+++ b/migrations/20190729144004-user-groups.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20190729144004-user-groups-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20190729144004-user-groups-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/20190730143144-cleanup-test-users.js
+++ b/migrations/20190730143144-cleanup-test-users.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20190730143144-cleanup-test-users-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20190730143144-cleanup-test-users-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20190729144004-user-groups-down.sql
+++ b/migrations/sqls/20190729144004-user-groups-down.sql
@@ -1,3 +1,5 @@
 DROP TABLE IF EXISTS idm.user_roles;
 DROP TABLE IF EXISTS idm.user_groups;
 DROP TABLE IF EXISTS idm.group_roles;
+DROP TABLE IF EXISTS idm.roles;
+DROP TABLE IF EXISTS idm.groups;

--- a/migrations/sqls/20190729144004-user-groups-down.sql
+++ b/migrations/sqls/20190729144004-user-groups-down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS idm.user_roles;
+DROP TABLE IF EXISTS idm.user_groups;
+DROP TABLE IF EXISTS idm.group_roles;

--- a/migrations/sqls/20190729144004-user-groups-up.sql
+++ b/migrations/sqls/20190729144004-user-groups-up.sql
@@ -1,72 +1,143 @@
 /* ensure function exists to generate GUID */
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
+/* create roles table */
+CREATE TABLE "idm"."roles" (
+    "role_id" character varying NOT NULL,
+    "application" idm.application_name,
+    "role" character varying NOT NULL,
+    "description" character varying NOT NULL,
+    date_created timestamp without time zone DEFAULT now(),
+    date_updated timestamp without time zone DEFAULT now(),
+    PRIMARY KEY ("role_id"),
+    UNIQUE(application, role)
+);
+
+/* create groups table */
+CREATE TABLE "idm"."groups" (
+    "group_id" character varying NOT NULL,
+    "application" idm.application_name,
+    "group" character varying NOT NULL,
+    "description" character varying NOT NULL,
+    date_created timestamp without time zone DEFAULT now(),
+    date_updated timestamp without time zone DEFAULT now(),
+    PRIMARY KEY ("group_id"),
+    UNIQUE(application, "group")
+);
+
 /* create user roles table */
 CREATE TABLE "idm"."user_roles" (
     "user_role_id" character varying NOT NULL,
     "user_id" integer NOT NULL,
-    "role" character varying NOT NULL,
+    "role_id" character varying NOT NULL,
+    date_created timestamp without time zone DEFAULT now(),
+    date_updated timestamp without time zone DEFAULT now(),
     PRIMARY KEY ("user_role_id"),
-    CONSTRAINT "user_id" FOREIGN KEY ("user_id") REFERENCES "idm"."users"("user_id") ON DELETE CASCADE
+    CONSTRAINT "user_id" FOREIGN KEY ("user_id") REFERENCES "idm"."users"("user_id") ON DELETE CASCADE,
+    CONSTRAINT "role_id" FOREIGN KEY ("role_id") REFERENCES "idm"."roles"("role_id") ON DELETE CASCADE
 );
 
 /* create user groups table */
 CREATE TABLE "idm"."user_groups" (
     "user_group_id" character varying NOT NULL,
     "user_id" integer NOT NULL,
-    "group" character varying NOT NULL,
+    "group_id" character varying NOT NULL,
+    date_created timestamp without time zone DEFAULT now(),
+    date_updated timestamp without time zone DEFAULT now(),
     PRIMARY KEY ("user_group_id"),
-    CONSTRAINT "user_id" FOREIGN KEY ("user_id") REFERENCES "idm"."users"("user_id") ON DELETE CASCADE
+    CONSTRAINT "user_id" FOREIGN KEY ("user_id") REFERENCES "idm"."users"("user_id") ON DELETE CASCADE,
+    CONSTRAINT "group_id" FOREIGN KEY ("group_id") REFERENCES "idm"."groups"("group_id") ON DELETE CASCADE
 );
 
 /* create group roles table */
 CREATE TABLE "idm"."group_roles" (
     "group_role_id" character varying NOT NULL,
-    "group" character varying NOT NULL,
-    "role" character varying NOT NULL,
-    PRIMARY KEY ("group_role_id")
+    "group_id" character varying NOT NULL,
+    "role_id" character varying NOT NULL,
+    date_created timestamp without time zone DEFAULT now(),
+    date_updated timestamp without time zone DEFAULT now(),
+    PRIMARY KEY ("group_role_id"),
+    UNIQUE(group_id, role_id),
+    CONSTRAINT "role_id" FOREIGN KEY ("role_id") REFERENCES "idm"."roles"("role_id") ON DELETE CASCADE,
+    CONSTRAINT "group_id" FOREIGN KEY ("group_id") REFERENCES "idm"."groups"("group_id") ON DELETE CASCADE
 );
 
+/* configure water_admin roles */
+INSERT INTO "idm"."roles" (role_id, application, role, description) VALUES
+  (gen_random_uuid(), 'water_admin', 'returns', 'Submit and edit returns'),
+  (gen_random_uuid(), 'water_admin', 'hof_notifications', 'Send HoF notifications'),
+  (gen_random_uuid(), 'water_admin', 'bulk_return_notifications', 'Send bulk return invitations and reminder notifications'),
+  (gen_random_uuid(), 'water_admin', 'manage_accounts', 'Create and manage internal user accounts'),
+  (gen_random_uuid(), 'water_admin', 'unlink_licences', 'Remove licences registered to a company'),
+  (gen_random_uuid(), 'water_admin', 'renewal_notifications', 'Send renewal notifications'),
+  (gen_random_uuid(), 'water_admin', 'ar_user', 'Edit licence data in Digitise! tool'),
+  (gen_random_uuid(), 'water_admin', 'ar_approver', 'Approve licence data in Digitise! tool');
+
+/* configure water_admin groups */
+INSERT INTO "idm"."groups" (group_id, application, "group", description) VALUES
+  (gen_random_uuid(), 'water_admin', 'environment_officer', 'Environment officer'),
+  (gen_random_uuid(), 'water_admin', 'billing_and_data', 'Water Resources Billing & Data'),
+  (gen_random_uuid(), 'water_admin', 'wirs', 'Waste Industry Regulatory Services'),
+  (gen_random_uuid(), 'water_admin', 'nps', 'National Permitting Service'),
+  (gen_random_uuid(), 'water_admin', 'psc', 'Permitting & Support Centre'),
+  (gen_random_uuid(), 'water_admin', 'super', 'Super user');
+
 /* configure group roles */
-INSERT INTO "idm"."group_roles" (group_role_id, "group", role) VALUES
-  (gen_random_uuid(), 'environment_officer', 'hof_notifications'),
-  (gen_random_uuid(), 'billing_and_data', 'returns'),
-  (gen_random_uuid(), 'billing_and_data', 'bulk_return_notifications'),
-  (gen_random_uuid(), 'billing_and_data', 'manage_accounts'),
-  (gen_random_uuid(), 'billing_and_data', 'unlink_licences'),
-  (gen_random_uuid(), 'wirs', 'returns'),
-  (gen_random_uuid(), 'nps', 'renewal_notifications'),
-  (gen_random_uuid(), 'nps', 'unlink_licences'),
-  (gen_random_uuid(), 'psc', 'renewal_notifications'),
-  (gen_random_uuid(), 'psc', 'unlink_licences'),
-  (gen_random_uuid(), 'super', 'hof_notifications'),
-  (gen_random_uuid(), 'super', 'returns'),
-  (gen_random_uuid(), 'super', 'bulk_return_notifications'),
-  (gen_random_uuid(), 'super', 'manage_accounts'),
-  (gen_random_uuid(), 'super', 'unlink_licences'),
-  (gen_random_uuid(), 'super', 'renewal_notifications'),
-  (gen_random_uuid(), 'super', 'ar_user'),
-  (gen_random_uuid(), 'super', 'ar_approver');
+INSERT INTO "idm"."group_roles" (group_role_id, group_id, role_id)
+  SELECT gen_random_uuid(), g.group_id, r.role_id
+  FROM idm.groups g
+  JOIN idm.roles r ON r.role='hof_notifications' AND r.application=g.application
+  WHERE g."group"='environment_officer' AND g.application='water_admin';
+
+INSERT INTO "idm"."group_roles" (group_role_id, group_id, role_id)
+  SELECT gen_random_uuid(), g.group_id, r.role_id
+  FROM idm.groups g
+  JOIN idm.roles r ON r.role IN('returns', 'bulk_return_notifications', 'manage_accounts', 'unlink_licences') AND r.application=g.application
+  WHERE g."group"='billing_and_data' AND g.application='water_admin';
+
+INSERT INTO "idm"."group_roles" (group_role_id, group_id, role_id)
+  SELECT gen_random_uuid(), g.group_id, r.role_id
+  FROM idm.groups g
+  JOIN idm.roles r ON r.role='returns' AND r.application=g.application
+  WHERE g."group"='wirs' AND g.application='water_admin';
+
+INSERT INTO "idm"."group_roles" (group_role_id, group_id, role_id)
+  SELECT gen_random_uuid(), g.group_id, r.role_id
+  FROM idm.groups g
+  JOIN idm.roles r ON r.role IN('renewal_notifications', 'unlink_licences') AND r.application=g.application
+  WHERE g."group"='nps' AND g.application='water_admin';
+
+INSERT INTO "idm"."group_roles" (group_role_id, group_id, role_id)
+  SELECT gen_random_uuid(), g.group_id, r.role_id
+  FROM idm.groups g
+  JOIN idm.roles r ON r.role IN('renewal_notifications', 'unlink_licences') AND r.application=g.application
+  WHERE g."group"='psc' AND g.application='water_admin';
+
+INSERT INTO "idm"."group_roles" (group_role_id, group_id, role_id)
+  SELECT gen_random_uuid(), g.group_id, r.role_id
+  FROM idm.groups g
+  JOIN idm.roles r ON r.application=g.application
+  WHERE g."group"='super' AND g.application='water_admin';
 
 /* set up groups for existing internal water_admin users */
-INSERT INTO "idm"."user_groups" (user_group_id, user_id, "group")
-  SELECT gen_random_uuid(), u.user_id, g.group
-  FROM idm.users u
-  JOIN (
-  	SELECT user_id,
-  	CASE
-  		WHEN (role->>'scopes')::jsonb ? 'returns' THEN 'wirs'
-  		WHEN (role->>'scopes')::jsonb ? 'ar_user' THEN 'nps'
-  		WHEN (role->>'scopes')::jsonb ? 'ar_approver' THEN 'nps'
-  	END AS "group"
-  	FROM idm.users u
-  	WHERE u.application='water_admin'
-  ) g ON u.user_id=g.user_id AND g.group IS NOT NULL;
+INSERT INTO "idm"."user_groups" (user_group_id, user_id, group_id)
+  SELECT gen_random_uuid(), u.user_id, g.group_id
+    FROM idm.users u
+    JOIN (
+    	SELECT user_id,
+    	CASE
+    		WHEN (role->>'scopes')::jsonb ? 'returns' THEN 'wirs'
+    		WHEN (role->>'scopes')::jsonb ? 'ar_user' THEN 'nps'
+    		WHEN (role->>'scopes')::jsonb ? 'ar_approver' THEN 'nps'
+    	END AS "group"
+    	FROM idm.users u
+    	WHERE u.application='water_admin'
+    ) ug ON u.user_id=ug.user_id AND ug.group IS NOT NULL
+    JOIN idm.groups g ON g.group=ug.group AND g.application='water_admin';
 
-
-  /* set up AR roles for existing internal water_admin users */
-INSERT INTO "idm"."user_roles" (user_role_id, user_id, role)
-  SELECT  gen_random_uuid(), u.user_id, r.role
+/* set up AR roles for existing internal water_admin users */
+INSERT INTO "idm"."user_roles" (user_role_id, user_id, role_id)
+  SELECT  gen_random_uuid(), u.user_id, r.role_id
   FROM idm.users u
   JOIN (
   	SELECT user_id,
@@ -76,4 +147,5 @@ INSERT INTO "idm"."user_roles" (user_role_id, user_id, role)
   	END AS "role"
   	FROM idm.users u
   	WHERE u.application='water_admin'
-  ) r ON u.user_id=r.user_id AND r.role IS NOT NULL;
+  ) ur ON u.user_id=ur.user_id AND ur.role IS NOT NULL
+  JOIN idm."roles" r ON ur.role=r.role AND r.application='water_admin';

--- a/migrations/sqls/20190729144004-user-groups-up.sql
+++ b/migrations/sqls/20190729144004-user-groups-up.sql
@@ -1,0 +1,79 @@
+/* ensure function exists to generate GUID */
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+/* create user roles table */
+CREATE TABLE "idm"."user_roles" (
+    "user_role_id" character varying NOT NULL,
+    "user_id" integer NOT NULL,
+    "role" character varying NOT NULL,
+    PRIMARY KEY ("user_role_id"),
+    CONSTRAINT "user_id" FOREIGN KEY ("user_id") REFERENCES "idm"."users"("user_id") ON DELETE CASCADE
+);
+
+/* create user groups table */
+CREATE TABLE "idm"."user_groups" (
+    "user_group_id" character varying NOT NULL,
+    "user_id" integer NOT NULL,
+    "group" character varying NOT NULL,
+    PRIMARY KEY ("user_group_id"),
+    CONSTRAINT "user_id" FOREIGN KEY ("user_id") REFERENCES "idm"."users"("user_id") ON DELETE CASCADE
+);
+
+/* create group roles table */
+CREATE TABLE "idm"."group_roles" (
+    "group_role_id" character varying NOT NULL,
+    "group" character varying NOT NULL,
+    "role" character varying NOT NULL,
+    PRIMARY KEY ("group_role_id")
+);
+
+/* configure group roles */
+INSERT INTO "idm"."group_roles" (group_role_id, "group", role) VALUES
+  (gen_random_uuid(), 'environment_officer', 'hof_notifications'),
+  (gen_random_uuid(), 'billing_and_data', 'returns'),
+  (gen_random_uuid(), 'billing_and_data', 'bulk_return_notifications'),
+  (gen_random_uuid(), 'billing_and_data', 'manage_accounts'),
+  (gen_random_uuid(), 'billing_and_data', 'unlink_licences'),
+  (gen_random_uuid(), 'wirs', 'returns'),
+  (gen_random_uuid(), 'nps', 'renewal_notifications'),
+  (gen_random_uuid(), 'nps', 'unlink_licences'),
+  (gen_random_uuid(), 'psc', 'renewal_notifications'),
+  (gen_random_uuid(), 'psc', 'unlink_licences'),
+  (gen_random_uuid(), 'super', 'hof_notifications'),
+  (gen_random_uuid(), 'super', 'returns'),
+  (gen_random_uuid(), 'super', 'bulk_return_notifications'),
+  (gen_random_uuid(), 'super', 'manage_accounts'),
+  (gen_random_uuid(), 'super', 'unlink_licences'),
+  (gen_random_uuid(), 'super', 'renewal_notifications'),
+  (gen_random_uuid(), 'super', 'ar_user'),
+  (gen_random_uuid(), 'super', 'ar_approver');
+
+/* set up groups for existing internal water_admin users */
+INSERT INTO "idm"."user_groups" (user_group_id, user_id, "group")
+  SELECT gen_random_uuid(), u.user_id, g.group
+  FROM idm.users u
+  JOIN (
+  	SELECT user_id,
+  	CASE
+  		WHEN (role->>'scopes')::jsonb ? 'returns' THEN 'wirs'
+  		WHEN (role->>'scopes')::jsonb ? 'ar_user' THEN 'nps'
+  		WHEN (role->>'scopes')::jsonb ? 'ar_approver' THEN 'nps'
+  	END AS "group"
+  	FROM idm.users u
+  	WHERE u.application='water_admin'
+  ) g ON u.user_id=g.user_id AND g.group IS NOT NULL;
+
+
+  /* set up AR roles for existing internal water_admin users */
+INSERT INTO "idm"."user_roles" (user_role_id, user_id, role)
+  SELECT  gen_random_uuid(), u.user_id, r.role
+  FROM idm.users u
+  JOIN (
+  	SELECT user_id,
+  	CASE
+  		WHEN (role->>'scopes')::jsonb ? 'ar_approver' THEN 'ar_approver'
+  		WHEN (role->>'scopes')::jsonb ? 'ar_user' THEN 'ar_user'
+  	END AS "role"
+  	FROM idm.users u
+  	WHERE u.application='water_admin'
+  ) r ON u.user_id=r.user_id AND r.role IS NOT NULL;

--- a/migrations/sqls/20190730143144-cleanup-test-users-down.sql
+++ b/migrations/sqls/20190730143144-cleanup-test-users-down.sql
@@ -1,0 +1,1 @@
+/* Replace with your SQL commands */

--- a/migrations/sqls/20190730143144-cleanup-test-users-up.sql
+++ b/migrations/sqls/20190730143144-cleanup-test-users-up.sql
@@ -1,0 +1,8 @@
+/* Replace with your SQL commands */
+DELETE FROM idm.users WHERE user_name LIKE 'test%@example.com'
+AND user_data->>'usertype'='external'
+AND (
+  user_data->>'firstname'='Dave'
+  OR
+  user_data->>'firstname'='User'
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,16 +33,23 @@
       }
     },
     "@envage/hapi-pg-rest-api": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@envage/hapi-pg-rest-api/-/hapi-pg-rest-api-4.1.2.tgz",
-      "integrity": "sha512-uVfbZEUCZzqxYkzJ8BZBH4pEBNU3okDsmx+FIPEp6nJ5r1xa1r9RbDKDAi7TqeOSerjBRmFk/AvdoR9OJZdbLA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@envage/hapi-pg-rest-api/-/hapi-pg-rest-api-5.0.0.tgz",
+      "integrity": "sha512-4NDCCUWlxfGYahjOOACT4R+/KWlL0SQztM5t1/t4U0rakqKekIKhmjgmyPCDlMSgff5TfmUVSKzYHIN3Egmraw==",
       "requires": {
         "es6-error": "^4.1.1",
         "joi": "^13.1.2",
         "lodash": "^4.17.11",
-        "moment": "^2.20.1",
+        "moment": "^2.24.0",
         "mongo-sql": "^5.1.0",
-        "uuid": "^3.1.0"
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "moment": {
+          "version": "2.24.0",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+          "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+        }
       }
     },
     "@envage/water-abstraction-helpers": {
@@ -3099,6 +3106,11 @@
         }
       }
     },
+    "hoek": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
+      "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
+    },
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
@@ -3653,9 +3665,9 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isemail": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.2.tgz",
-      "integrity": "sha512-zfRhJn9rFSGhzU5tGZqepRSAj3+g6oTOHxMGGriWNJZzyLPUK8H7VHpqKntegnW8KLyGA9zwuNaCoopl40LTpg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
       "requires": {
         "punycode": "2.x.x"
       },
@@ -3685,20 +3697,13 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "joi": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-13.4.0.tgz",
-      "integrity": "sha512-JuK4GjEu6j7zr9FuVe2MAseZ6si/8/HaY0qMAejfDFHp7jcH4OKE937mIHM5VT4xDS0q7lpQbszbxKV9rm0yUg==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
+      "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
       "requires": {
         "hoek": "5.x.x",
         "isemail": "3.x.x",
         "topo": "3.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
-          "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw=="
-        }
       }
     },
     "js-yaml": {
@@ -6831,17 +6836,17 @@
       "dev": true
     },
     "topo": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
-      "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
       "requires": {
-        "hoek": "5.x.x"
+        "hoek": "6.x.x"
       },
       "dependencies": {
         "hoek": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
-          "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw=="
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+          "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
     "snyk": "^1.199.2"
   },
   "dependencies": {
-    "@hapi/hapi": "^18.3.1",
+    "@envage/hapi-pg-rest-api": "^5.0.0",
+    "@envage/water-abstraction-helpers": "^3.0.0",
     "@hapi/boom": "^7.4.2",
     "@hapi/good": "^8.2.0",
+    "@hapi/hapi": "^18.3.1",
     "@hapi/joi": "^15.1.0",
-    "@envage/hapi-pg-rest-api": "^4.1.2",
-    "@envage/water-abstraction-helpers": "^3.0.0",
     "bcrypt": "^3.0.6",
     "blipp": "^4.0.0",
     "dotenv": "^8.0.0",

--- a/src/controllers/change-email.js
+++ b/src/controllers/change-email.js
@@ -1,6 +1,6 @@
 const { logger } = require('../logger');
 const helpers = require('../lib/change-email-helpers');
-const repos = require('../lib/change-email-repos');
+const repos = require('../lib/repos');
 
 class EmailChangeError extends Error {
   constructor (message, statusCode) {

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -1,54 +1,79 @@
 const HAPIRestAPI = require('@envage/hapi-pg-rest-api');
 const Joi = require('@hapi/joi');
+const { omit } = require('lodash');
+
 const { createHash } = require('../lib/helpers');
 
-module.exports = (config = {}) => {
-  const { pool, version } = config;
-  return new HAPIRestAPI({
-    table: 'idm.users',
-    primaryKey: 'user_id',
-    endpoint: '/idm/' + version + '/user',
-    connection: pool,
-    primaryKeyAuto: true,
-    primaryKeyGuid: false,
-    postSelect: (data) => {
-      return data.map(row => {
-        // Don't include password in returned data
-        const { password, ...rest } = row;
-        return rest;
-      });
-    },
-    preQuery: async (request) => {
-      // Hash passwords found in data
-      if ('password' in request.data) {
-        request.data.password = await createHash(request.data.password);
-      }
-      // Support find user by ID or email
-      if ('user_id' in request.filter) {
-        if (request.filter.user_id.match(/@/)) {
-          request.filter.user_name = request.filter.user_id;
-          delete request.filter.user_id;
-        }
-      }
-      return request;
-    },
-    onCreateTimestamp: 'date_created',
-    onUpdateTimestamp: 'date_updated',
-    validation: {
-      user_id: [Joi.number().required(), Joi.string().email().required().lowercase()],
-      user_name: Joi.string().email().trim().lowercase(),
-      password: Joi.string(),
-      user_data: Joi.object(),
-      reset_guid: Joi.string().guid().allow(null),
-      reset_guid_date_created: Joi.string().allow(null),
-      reset_required: Joi.number(),
-      last_login: Joi.string(),
-      bad_logins: Joi.number(),
-      date_created: Joi.string().allow(null),
-      date_updated: Joi.string().allow(null),
-      application: Joi.string(),
-      role: Joi.object().allow(null),
-      external_id: Joi.string().allow(null)
+const { usersRepo } = require('../lib/repos');
+const { pool } = require('../lib/connectors/db');
+const { version } = require('../../config');
+
+const restApi = new HAPIRestAPI({
+  table: 'idm.users',
+  primaryKey: 'user_id',
+  endpoint: '/idm/' + version + '/user',
+  connection: pool,
+  primaryKeyAuto: true,
+  primaryKeyGuid: false,
+  postSelect: (data) => {
+    return data.map(row => {
+      // Don't include password in returned data
+      const { password, ...rest } = row;
+      return rest;
+    });
+  },
+  preQuery: async (request) => {
+    // Hash passwords found in data
+    if ('password' in request.data) {
+      request.data.password = await createHash(request.data.password);
     }
-  });
+    return request;
+  },
+  onCreateTimestamp: 'date_created',
+  onUpdateTimestamp: 'date_updated',
+  validation: {
+    user_id: [Joi.number().required(), Joi.string().email().required().lowercase()],
+    user_name: Joi.string().email().trim().lowercase(),
+    password: Joi.string(),
+    user_data: Joi.object(),
+    reset_guid: Joi.string().guid().allow(null),
+    reset_guid_date_created: Joi.string().allow(null),
+    reset_required: Joi.number(),
+    last_login: Joi.string(),
+    bad_logins: Joi.number(),
+    date_created: Joi.string().allow(null),
+    date_updated: Joi.string().allow(null),
+    application: Joi.string(),
+    role: Joi.object().allow(null),
+    external_id: Joi.string().allow(null)
+  }
+});
+
+/**
+ * Override find one handler
+ * @param  {[type]}  request [description]
+ * @param  {[type]}  h       [description]
+ * @return {Promise}         [description]
+ */
+restApi.routes.findOneRoute.handler = async (request, h) => {
+  const { id } = request.params;
+
+  const [ user, roles, groups ] = await Promise.all([
+    usersRepo.findById(id),
+    usersRepo.findRoles(id),
+    usersRepo.findGroups(id)
+  ]);
+
+  if (user) {
+    user.roles = roles;
+    user.groups = groups;
+    return { error: null, data: omit(user, 'password') };
+  }
+
+  return h.response({
+    error: 'User not found',
+    data: null
+  }).code(404);
 };
+
+module.exports = restApi.getRoutes();

--- a/src/lib/change-email-helpers.js
+++ b/src/lib/change-email-helpers.js
@@ -1,6 +1,6 @@
 const helpers = require('./helpers');
 const { EmailChangeError } = require('../controllers/change-email');
-const repos = require('./change-email-repos');
+const repos = require('./repos');
 
 /**
  * Checks password which was entered by user

--- a/src/lib/repos/index.js
+++ b/src/lib/repos/index.js
@@ -1,6 +1,6 @@
-const UsersRepository = require('./repos/users');
-const ChangeEmailRepository = require('./repos/change-email');
-const { pool } = require('../lib/connectors/db');
+const UsersRepository = require('./users');
+const ChangeEmailRepository = require('./change-email');
+const { pool } = require('../../lib/connectors/db');
 
 const usersRepo = new UsersRepository({
   connection: pool,

--- a/src/lib/repos/users.js
+++ b/src/lib/repos/users.js
@@ -1,10 +1,54 @@
 const Repository = require('@envage/hapi-pg-rest-api/src/repository');
 
+const mapRole = row => row.role;
+const mapGroup = row => row.group;
+
+/**
+ * Repository for idm.users table
+ * @extends Repository
+ */
 class UsersRepository extends Repository {
+  /**
+   * Finds a user by ID
+   * @param  {Number}  userId
+   * @return {Promise<Object>}
+   */
   async findById (userId) {
-    const user = await this.find({ user_id: userId });
-    return user.rows[0];
+    const { rows: [user] } = await this.find({ user_id: userId });
+    return user;
   }
+
+  async findGroups (userId) {
+    const query = `SELECT g.group FROM idm.users u
+      JOIN idm.user_groups ug ON u.user_id=ug.user_id
+      JOIN idm.groups g ON ug.group_id=g.group_id
+      WHERE u.user_id=$1`;
+    const { rows } = await this.dbQuery(query, [userId]);
+    return rows.map(mapGroup);
+  }
+
+  /**
+   * Returns an array of roles for the specified user ID.
+   * This combines the roles explicitly set for the user in the user_roles
+   * table with the ones they get as a result of their group
+   * @param  {Number}  userId
+   * @return {Promise<Array>}
+   */
+  async findRoles (userId) {
+    const query = `
+      SELECT r.role FROM idm.users u
+        JOIN idm.user_groups ug ON u.user_id=ug.user_id
+        JOIN idm.group_roles gr ON ug.group_id=gr.group_id
+        JOIN idm.roles r ON gr.role_id = r.role_id
+        WHERE u.user_id=$1
+      UNION SELECT r.role FROM idm.users u
+        JOIN idm.user_roles ur ON u.user_id=ur.user_id
+        JOIN idm.roles r ON ur.role_id=r.role_id
+        WHERE u.user_id=$1`;
+    const { rows } = await this.dbQuery(query, [userId]);
+    return rows.map(mapRole);
+  }
+
   checkEmailAddress (verificationId, newEmail) {
     const query = `SELECT user_name FROM idm.users u
       JOIN (
@@ -17,6 +61,13 @@ class UsersRepository extends Repository {
 
     return this.dbQuery(query, [verificationId, newEmail]);
   }
+
+  /**
+   * Sets the email address of the user with the specified ID to a new value
+   * @param  {Number} userId   - user ID
+   * @param  {String} newEmail - the new email address
+   * @return {Promise}
+   */
   updateEmailAddress (userId, newEmail) {
     const filter = { user_id: userId };
     const data = { user_name: newEmail };

--- a/src/routes/idm.js
+++ b/src/routes/idm.js
@@ -10,7 +10,7 @@ const apiConfig = {
 
 const resetController = require('../controllers/reset');
 const changeEmailController = require('../controllers/change-email');
-const UsersController = require('../controllers/user')(apiConfig);
+const usersRoutes = require('../controllers/user');
 const KpiApi = require('../controllers/kpi-reports.js')(apiConfig);
 const statusController = require('../controllers/status');
 
@@ -24,7 +24,7 @@ module.exports = [
       description: 'Status placeholder'
     }
   },
-  ...UsersController.getRoutes(),
+  ...usersRoutes,
   {
     method: 'PATCH',
     path: '/idm/' + version + '/reset/{application}/{email}',

--- a/src/routes/idm.js
+++ b/src/routes/idm.js
@@ -33,7 +33,7 @@ module.exports = [
       validate: {
         params: {
           email: Joi.string().email().required(),
-          application: Joi.string().email().required()
+          application: Joi.string().required()
         },
         query: {
           mode: Joi.string().valid('reset', 'new', 'existing', 'sharing'),

--- a/test/auth.js
+++ b/test/auth.js
@@ -15,6 +15,7 @@ const { expect } = require('@hapi/code');
 const server = require('../index');
 
 let createdEmails = [];
+let testUserIds = [];
 
 async function createUser (email, password, application = 'water_vml') {
   createdEmails.push(email);
@@ -39,18 +40,28 @@ async function createUser (email, password, application = 'water_vml') {
   expect(payload.error).to.equal(null);
   expect(payload.data.user_id).to.be.a.number();
 
+  testUserIds.push(payload.data.user_id);
+
   // Return user ID for future tests
   return payload.data.user_id;
 }
 
+const createRequest = (method = 'GET', url = '/idm/1.0/user') => ({
+  method,
+  url,
+  headers: { Authorization: process.env.JWT_TOKEN }
+});
+
+const createDeleteRequest = id => createRequest('DELETE', `/idm/1.0/user/${id}`);
+
 async function deleteUsers () {
-  const requests = createdEmails.map(email => ({
-    method: 'DELETE',
-    url: `/idm/1.0/user/${email}`,
-    headers: { Authorization: process.env.JWT_TOKEN }
-  })).map(request => server.inject(request));
+  const requests = testUserIds
+    .map(createDeleteRequest)
+    .map(request => server.inject(request));
 
   await Promise.all(requests);
+
+  testUserIds = [];
 }
 
 async function getUser (userId) {

--- a/test/controllers/change-email.js
+++ b/test/controllers/change-email.js
@@ -1,6 +1,6 @@
 const controller = require('../../src/controllers/change-email');
 const helpers = require('../../src/lib/change-email-helpers');
-const repos = require('../../src/lib/change-email-repos');
+const repos = require('../../src/lib/repos');
 const { expect } = require('@hapi/code');
 const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
 const sinon = require('sinon');

--- a/test/lib/change-email-helpers.js
+++ b/test/lib/change-email-helpers.js
@@ -1,6 +1,6 @@
 const changeEmailHelpers = require('../../src/lib/change-email-helpers');
 const helpers = require('../../src/lib/helpers');
-const repos = require('../../src/lib/change-email-repos');
+const repos = require('../../src/lib/repos');
 const { expect } = require('@hapi/code');
 const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
 const sinon = require('sinon');

--- a/test/lib/repos/change-email.js
+++ b/test/lib/repos/change-email.js
@@ -1,5 +1,5 @@
 const Repository = require('@envage/hapi-pg-rest-api/src/repository');
-const repos = require('../../../src/lib/change-email-repos');
+const repos = require('../../../src/lib/repos');
 const helpers = require('../../../src/lib/helpers');
 const { expect } = require('@hapi/code');
 const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -22,7 +22,13 @@ const deleteUser = async userID => {
   return result;
 };
 
+const deleteTestUsers = () => {
+  const query = `DELETE FROM idm.users WHERE user_data->>'unitTest'='true'`;
+  return DB.query(query);
+};
+
 module.exports = {
   createUser,
-  deleteUser
+  deleteUser,
+  deleteTestUsers
 };

--- a/test/users.js
+++ b/test/users.js
@@ -13,6 +13,7 @@ const { experiment, test, beforeEach, after } = exports.lab = require('@hapi/lab
 const { get } = require('lodash');
 const { expect } = require('@hapi/code');
 const server = require('../index');
+const { deleteTestUsers } = require('./test-helpers');
 
 // A user is always created with testEmailOne as part of the beforeEach.
 const testEmailOne = 'test1@example.com';
@@ -29,25 +30,17 @@ const createRequest = (method = 'GET', url = '/idm/1.0/user') => ({
   headers: { Authorization: process.env.JWT_TOKEN }
 });
 
-const createDeleteRequest = id => createRequest('DELETE', `/idm/1.0/user/${id}`);
 const createGetRequest = id => createRequest('GET', `/idm/1.0/user/${id}`);
-
-async function deleteTestUsers () {
-  const requests = testUserIds
-    .map(createDeleteRequest)
-    .map(request => server.inject(request));
-
-  await Promise.all(requests);
-
-  testUserIds = [];
-}
 
 const createTestUser = async (userName = testEmailOne, application = 'water_vml') => {
   const request = createRequest('POST');
   request.payload = {
     user_name: userName,
     application,
-    password: uuidv4()
+    password: uuidv4(),
+    user_data: {
+      unitTest: true
+    }
   };
 
   const response = await server.inject(request);


### PR DESCRIPTION
Creates tables to manage groups and roles.
Migrates existing user data in `roles` json blob to the new tables.
Adds `roles` and `groups` as arrays in the response from the find one user API.
Removes the ability to find a user by email address - as the same email address could be in multiple applications, this could lead to unexpected results.