### PR TITLE
Chore: Delete user roles/groups for acceptance tests

### DIFF
--- a/src/modules/acceptance-tests/controller.js
+++ b/src/modules/acceptance-tests/controller.js
@@ -2,7 +2,32 @@ const db = require('../../lib/connectors/db');
 const ACCEPTANCE_TEST_SOURCE = 'acceptance-test-setup';
 const config = require('../../../config');
 
+const deleteUserRoles = () => {
+  return db.query(`
+    delete
+      from idm.user_groups ug
+      using idm.users u
+    where
+      ug.user_id = u.user_id
+      and
+      u.user_data->>'source' = '${ACCEPTANCE_TEST_SOURCE}';
+  `);
+};
+
+const deleteUserGroups = () => {
+  return db.query(`
+    delete
+      from idm.user_groups ug
+      using idm.users u
+    where
+      ug.user_id = u.user_id
+      and
+      u.user_data->>'source' = '${ACCEPTANCE_TEST_SOURCE}';
+  `);
+};
+
 const deleteAcceptanceTestData = async (request, h) => {
+  await Promise.all([deleteUserRoles(), deleteUserGroups()]);
   await db.query(`
     delete
     from idm.users


### PR DESCRIPTION
In addition to deleting users with a known value in the user_data field,
this now cascades to delete any user_groups or user_roles to facilitate
the set up and tear down of internal users for acceptance testing.