### PR TITLE
Removes @example.com users during acceptance test teardown

### DIFF
--- a/src/lib/connectors/notify.js
+++ b/src/lib/connectors/notify.js
@@ -60,9 +60,9 @@ function sendPasswordResetEmail (params, mode = 'reset') {
   const personalisation = {
     firstName,
     resetUrl: getPasswordResetUrl(resetGuid, userApplication),
-    createUrl: `${process.env.BASE_URL}/create-password?resetGuid=${resetGuid}&utm_source=system&utm_medium=email&utm_campaign=create_password`,
-    shareUrl: `${process.env.BASE_URL}/create-password?resetGuid=${resetGuid}&utm_source=system&utm_medium=email&utm_campaign=share_access`,
-    loginUrl: `${process.env.BASE_URL}/signin?utm_source=system&utm_medium=email&utm_campaign=send_login`,
+    createUrl: `${application.water_vml}/create-password?resetGuid=${resetGuid}&utm_source=system&utm_medium=email&utm_campaign=create_password`,
+    shareUrl: `${application.water_vml}/create-password?resetGuid=${resetGuid}&utm_source=system&utm_medium=email&utm_campaign=share_access`,
+    loginUrl: `${application.water_vml}/signin?utm_source=system&utm_medium=email&utm_campaign=send_login`,
     sender
   };
   const messageRefs = {

--- a/src/modules/acceptance-tests/controller.js
+++ b/src/modules/acceptance-tests/controller.js
@@ -6,7 +6,8 @@ const deleteAcceptanceTestData = async (request, h) => {
   await pool.query(`
     delete
     from idm.users
-    where user_data->>'source' = '${ACCEPTANCE_TEST_SOURCE}';
+    where user_data->>'source' = '${ACCEPTANCE_TEST_SOURCE}' 
+    or user_name like '%@example.com';
   `);
 
   return h.response().code(204);


### PR DESCRIPTION
* Removes @example.com users during acceptance test teardown
* Uses config option rather than environment variable directly when sending notifications - this ensures defaults are used