### PR TITLE
Replace ESLint with StandardJS

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,0 @@
-# node_modules ignored by default
-migrations

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "extends": "standard",
-   "rules": {
-        "semi": [2, "always"]
-    }
-}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 12.x, 14.x ]
+        node-version: [ 14.x, 16.x ]
     name: Test  - Node.js ${{ matrix.node-version }}
     env:
       # These need to be duplicated in services section for postgres. Unfortunately, there is not a way to reuse them

--- a/config.js
+++ b/config.js
@@ -1,5 +1,5 @@
-const testMode = parseInt(process.env.TEST_MODE) === 1;
-const isAcceptanceTestTarget = ['local', 'dev', 'development', 'test', 'qa', 'preprod'].includes(process.env.NODE_ENV);
+const testMode = parseInt(process.env.TEST_MODE) === 1
+const isAcceptanceTestTarget = ['local', 'dev', 'development', 'test', 'qa', 'preprod'].includes(process.env.NODE_ENV)
 
 module.exports = {
   version: '1.0',
@@ -66,4 +66,4 @@ module.exports = {
   },
 
   isAcceptanceTestTarget
-};
+}

--- a/index.js
+++ b/index.js
@@ -1,36 +1,36 @@
-'use strict';
+'use strict'
 
-require('dotenv').config();
+require('dotenv').config()
 
-const GoodWinston = require('good-winston');
-const Hapi = require('@hapi/hapi');
+const GoodWinston = require('good-winston')
+const Hapi = require('@hapi/hapi')
 
 const serverPlugins = {
   blipp: require('blipp'),
   hapiAuthJwt2: require('hapi-auth-jwt2'),
   good: require('@hapi/good')
-};
+}
 
-const config = require('./config');
-const db = require('./src/lib/connectors/db');
-const { logger } = require('./src/logger');
-const goodWinstonStream = new GoodWinston({ winston: logger });
+const config = require('./config')
+const db = require('./src/lib/connectors/db')
+const { logger } = require('./src/logger')
+const goodWinstonStream = new GoodWinston({ winston: logger })
 
-const server = new Hapi.Server(config.server);
+const server = new Hapi.Server(config.server)
 
 const validateJWT = (decoded, request, h) => {
-  logger.info(request.path);
-  logger.info(request.payload);
-  logger.info('CALL WITH TOKEN');
-  logger.info(decoded);
+  logger.info(request.path)
+  logger.info(request.payload)
+  logger.info('CALL WITH TOKEN')
+  logger.info(decoded)
   // TODO: JWT tokens to DB...
   // do your checks to see if the person is valid
 
-  const isValid = !!decoded.id;
-  const message = isValid ? 'huzah... JWT OK' : 'boo... JWT failed';
-  logger.info(message);
-  return { isValid };
-};
+  const isValid = !!decoded.id
+  const message = isValid ? 'huzah... JWT OK' : 'boo... JWT failed'
+  logger.info(message)
+  return { isValid }
+}
 
 const initGood = async () => {
   await server.register({
@@ -41,15 +41,15 @@ const initGood = async () => {
         winston: [goodWinstonStream]
       }
     }
-  });
-};
+  })
+}
 
 const initBlipp = async () => {
   await server.register({
     plugin: serverPlugins.blipp,
     options: config.blipp
-  });
-};
+  })
+}
 
 const configureJwtStrategy = () => {
   server.auth.strategy('jwt', 'jwt', {
@@ -57,50 +57,50 @@ const configureJwtStrategy = () => {
     validate: validateJWT, // validate function defined above
     verifyOptions: {}, // pick a strong algorithm
     verify: validateJWT
-  });
+  })
 
-  server.auth.default('jwt');
-};
+  server.auth.default('jwt')
+}
 
 const init = async () => {
-  initGood();
-  initBlipp();
+  initGood()
+  initBlipp()
 
-  await server.register({ plugin: serverPlugins.hapiAuthJwt2 });
+  await server.register({ plugin: serverPlugins.hapiAuthJwt2 })
 
-  configureJwtStrategy();
+  configureJwtStrategy()
 
   // load routes
-  server.route(require('./src/routes/idm'));
+  server.route(require('./src/routes/idm'))
 
   if (!module.parent) {
-    await server.start();
-    const name = process.env.SERVICE_NAME;
-    const uri = server.info.uri;
-    server.log('info', `Service ${name} running at: ${uri}`);
+    await server.start()
+    const name = process.env.SERVICE_NAME
+    const uri = server.info.uri
+    server.log('info', `Service ${name} running at: ${uri}`)
   }
-};
+}
 
 const processError = message => err => {
-  logger.error(message, err);
-  process.exit(1);
-};
+  logger.error(message, err)
+  process.exit(1)
+}
 
 process
   .on('unhandledRejection', processError('unhandledRejection'))
   .on('uncaughtException', processError('uncaughtException'))
   .on('SIGINT', async () => {
-    logger.info('Stopping IDM service');
+    logger.info('Stopping IDM service')
 
-    await server.stop();
-    logger.info('1/2: Hapi server stopped');
+    await server.stop()
+    logger.info('1/2: Hapi server stopped')
 
-    await db.pool.end();
-    logger.info('2/2: Connection pool closed');
+    await db.pool.end()
+    logger.info('2/2: Connection pool closed')
 
-    return process.exit(0);
-  });
+    return process.exit(0)
+  })
 
-init();
+init()
 
-module.exports = server;
+module.exports = server

--- a/migrations/20171201101811-idm.js
+++ b/migrations/20171201101811-idm.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20171201101811-idm.js
+++ b/migrations/20171201101811-idm.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20171201101811-idm-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20171201101811-idm-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20171201101811-idm-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20171201101811-idm-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20171213091237-unique-username.js
+++ b/migrations/20171213091237-unique-username.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20171213091237-unique-username.js
+++ b/migrations/20171213091237-unique-username.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20171213091237-unique-username-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20171213091237-unique-username-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20171213091237-unique-username-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20171213091237-unique-username-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20171214130749-fix-timestamp-login.js
+++ b/migrations/20171214130749-fix-timestamp-login.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20171214130749-fix-timestamp-login.js
+++ b/migrations/20171214130749-fix-timestamp-login.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20171214130749-fix-timestamp-login-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20171214130749-fix-timestamp-login-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20171214130749-fix-timestamp-login-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20171214130749-fix-timestamp-login-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20171218084708-setup-wab-team.js
+++ b/migrations/20171218084708-setup-wab-team.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20171218084708-setup-wab-team.js
+++ b/migrations/20171218084708-setup-wab-team.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20171218084708-setup-wab-team-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20171218084708-setup-wab-team-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20171218084708-setup-wab-team-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20171218084708-setup-wab-team-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20180131092635-add-user-type.js
+++ b/migrations/20180131092635-add-user-type.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20180131092635-add-user-type.js
+++ b/migrations/20180131092635-add-user-type.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180131092635-add-user-type-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180131092635-add-user-type-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180131092635-add-user-type-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180131092635-add-user-type-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20180430144211-add-kpi-reports.js
+++ b/migrations/20180430144211-add-kpi-reports.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20180430144211-add-kpi-reports.js
+++ b/migrations/20180430144211-add-kpi-reports.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180430144211-add-kpi-reports-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180430144211-add-kpi-reports-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180430144211-add-kpi-reports-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180430144211-add-kpi-reports-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20180501124503-fix-daves-stoopid.js
+++ b/migrations/20180501124503-fix-daves-stoopid.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20180501124503-fix-daves-stoopid.js
+++ b/migrations/20180501124503-fix-daves-stoopid.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180501124503-fix-daves-stoopid-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180501124503-fix-daves-stoopid-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180501124503-fix-daves-stoopid-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180501124503-fix-daves-stoopid-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20180712131745-change-user-data-type.js
+++ b/migrations/20180712131745-change-user-data-type.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20180712131745-change-user-data-type.js
+++ b/migrations/20180712131745-change-user-data-type.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180712131745-change-user-data-type-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180712131745-change-user-data-type-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180712131745-change-user-data-type-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180712131745-change-user-data-type-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20180718133110-users-add-roles-and-application.js
+++ b/migrations/20180718133110-users-add-roles-and-application.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20180718133110-users-add-roles-and-application.js
+++ b/migrations/20180718133110-users-add-roles-and-application.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180718133110-users-add-roles-and-application-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180718133110-users-add-roles-and-application-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180718133110-users-add-roles-and-application-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180718133110-users-add-roles-and-application-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20180718214743-users-composite-unique-constraint.js
+++ b/migrations/20180718214743-users-composite-unique-constraint.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20180718214743-users-composite-unique-constraint.js
+++ b/migrations/20180718214743-users-composite-unique-constraint.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180718214743-users-composite-unique-constraint-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180718214743-users-composite-unique-constraint-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180718214743-users-composite-unique-constraint-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180718214743-users-composite-unique-constraint-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20180720134957-set-user-application-and-remove-admin.js
+++ b/migrations/20180720134957-set-user-application-and-remove-admin.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20180720134957-set-user-application-and-remove-admin.js
+++ b/migrations/20180720134957-set-user-application-and-remove-admin.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180720134957-set-user-application-and-remove-admin-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180720134957-set-user-application-and-remove-admin-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180720134957-set-user-application-and-remove-admin-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180720134957-set-user-application-and-remove-admin-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20180724104315-users-add-external-id.js
+++ b/migrations/20180724104315-users-add-external-id.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20180724104315-users-add-external-id.js
+++ b/migrations/20180724104315-users-add-external-id.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180724104315-users-add-external-id-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180724104315-users-add-external-id-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20180724104315-users-add-external-id-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20180724104315-users-add-external-id-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20181108142402-users-add-reset-guid-date-created.js
+++ b/migrations/20181108142402-users-add-reset-guid-date-created.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20181108142402-users-add-reset-guid-date-created.js
+++ b/migrations/20181108142402-users-add-reset-guid-date-created.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20181108142402-users-add-reset-guid-date-created-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20181108142402-users-add-reset-guid-date-created-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20181108142402-users-add-reset-guid-date-created-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20181108142402-users-add-reset-guid-date-created-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20190605101404-internal-users-to-new-application-name.js
+++ b/migrations/20190605101404-internal-users-to-new-application-name.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20190605101404-internal-users-to-new-application-name.js
+++ b/migrations/20190605101404-internal-users-to-new-application-name.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190605101404-internal-users-to-new-application-name-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190605101404-internal-users-to-new-application-name-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190605101404-internal-users-to-new-application-name-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190605101404-internal-users-to-new-application-name-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20190703092645-change-email-verification.js
+++ b/migrations/20190703092645-change-email-verification.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20190703092645-change-email-verification.js
+++ b/migrations/20190703092645-change-email-verification.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190703092645-change-email-verification-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190703092645-change-email-verification-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190703092645-change-email-verification-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190703092645-change-email-verification-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20190729144004-user-groups.js
+++ b/migrations/20190729144004-user-groups.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20190729144004-user-groups.js
+++ b/migrations/20190729144004-user-groups.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190729144004-user-groups-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190729144004-user-groups-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190729144004-user-groups-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190729144004-user-groups-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20190730143144-cleanup-test-users.js
+++ b/migrations/20190730143144-cleanup-test-users.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20190730143144-cleanup-test-users.js
+++ b/migrations/20190730143144-cleanup-test-users.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190730143144-cleanup-test-users-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190730143144-cleanup-test-users-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190730143144-cleanup-test-users-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190730143144-cleanup-test-users-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20190802120734-change-email-attempts-count.js
+++ b/migrations/20190802120734-change-email-attempts-count.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20190802120734-change-email-attempts-count.js
+++ b/migrations/20190802120734-change-email-attempts-count.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190802120734-change-email-attempts-count-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190802120734-change-email-attempts-count-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190802120734-change-email-attempts-count-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190802120734-change-email-attempts-count-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20190807163156-reauth.js
+++ b/migrations/20190807163156-reauth.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20190807163156-reauth.js
+++ b/migrations/20190807163156-reauth.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190807163156-reauth-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190807163156-reauth-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190807163156-reauth-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190807163156-reauth-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20190808125024-email-change.js
+++ b/migrations/20190808125024-email-change.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20190808125024-email-change.js
+++ b/migrations/20190808125024-email-change.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190808125024-email-change-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190808125024-email-change-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190808125024-email-change-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190808125024-email-change-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20190816131841-enabled-users.js
+++ b/migrations/20190816131841-enabled-users.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20190816131841-enabled-users.js
+++ b/migrations/20190816131841-enabled-users.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190816131841-enabled-users-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190816131841-enabled-users-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190816131841-enabled-users-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190816131841-enabled-users-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20190827110406-alter-pgcryto-extension-schema.js
+++ b/migrations/20190827110406-alter-pgcryto-extension-schema.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20190827110406-alter-pgcryto-extension-schema.js
+++ b/migrations/20190827110406-alter-pgcryto-extension-schema.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190827110406-alter-pgcryto-extension-schema-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190827110406-alter-pgcryto-extension-schema-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190827110406-alter-pgcryto-extension-schema-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190827110406-alter-pgcryto-extension-schema-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20190828155617-new-charging-role.js
+++ b/migrations/20190828155617-new-charging-role.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20190828155617-new-charging-role.js
+++ b/migrations/20190828155617-new-charging-role.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190828155617-new-charging-role-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190828155617-new-charging-role-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20190828155617-new-charging-role-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20190828155617-new-charging-role-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20191127111358-new-billing-role.js
+++ b/migrations/20191127111358-new-billing-role.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20191127111358-new-billing-role.js
+++ b/migrations/20191127111358-new-billing-role.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20191127111358-new-billing-role-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20191127111358-new-billing-role-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20191127111358-new-billing-role-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20191127111358-new-billing-role-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20200116122318-roles-based-indexes.js
+++ b/migrations/20200116122318-roles-based-indexes.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20200116122318-roles-based-indexes.js
+++ b/migrations/20200116122318-roles-based-indexes.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20200116122318-roles-based-indexes-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20200116122318-roles-based-indexes-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20200116122318-roles-based-indexes-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20200116122318-roles-based-indexes-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20200820074624-add-charge-version-workflow-roles.js
+++ b/migrations/20200820074624-add-charge-version-workflow-roles.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20200820074624-add-charge-version-workflow-roles.js
+++ b/migrations/20200820074624-add-charge-version-workflow-roles.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20200820074624-add-charge-version-workflow-roles-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20200820074624-add-charge-version-workflow-roles-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20200820074624-add-charge-version-workflow-roles-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20200820074624-add-charge-version-workflow-roles-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20200923143302-agreements-roles.js
+++ b/migrations/20200923143302-agreements-roles.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20200923143302-agreements-roles.js
+++ b/migrations/20200923143302-agreements-roles.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20200923143302-agreements-roles-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20200923143302-agreements-roles-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20200923143302-agreements-roles-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20200923143302-agreements-roles-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20201016094050-allow-billing-and-data-to-edit-charge-workflows.js
+++ b/migrations/20201016094050-allow-billing-and-data-to-edit-charge-workflows.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20201016094050-allow-billing-and-data-to-edit-charge-workflows.js
+++ b/migrations/20201016094050-allow-billing-and-data-to-edit-charge-workflows.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20201016094050-allow-billing-and-data-to-edit-charge-workflows-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20201016094050-allow-billing-and-data-to-edit-charge-workflows-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20201016094050-allow-billing-and-data-to-edit-charge-workflows-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20201016094050-allow-billing-and-data-to-edit-charge-workflows-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20201117151936-billing-account-roles.js
+++ b/migrations/20201117151936-billing-account-roles.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20201117151936-billing-account-roles.js
+++ b/migrations/20201117151936-billing-account-roles.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20201117151936-billing-account-roles-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20201117151936-billing-account-roles-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20201117151936-billing-account-roles-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20201117151936-billing-account-roles-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20210611125925-create-waa-role.js
+++ b/migrations/20210611125925-create-waa-role.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20210611125925-create-waa-role.js
+++ b/migrations/20210611125925-create-waa-role.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20210611125925-create-waa-role-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20210611125925-create-waa-role-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20210611125925-create-waa-role-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20210611125925-create-waa-role-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/migrations/20210623091731-nps-psc-charging-permissions.js
+++ b/migrations/20210623091731-nps-psc-charging-permissions.js
@@ -1,8 +1,5 @@
 'use strict'
 
-let dbm
-let type
-let seed
 const fs = require('fs')
 const path = require('path')
 let Promise
@@ -11,10 +8,7 @@ let Promise
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function (options, seedLink) {
-  dbm = options.dbmigrate
-  type = dbm.dataType
-  seed = seedLink
+exports.setup = function (options, _seedLink) {
   Promise = options.Promise
 }
 

--- a/migrations/20210623091731-nps-psc-charging-permissions.js
+++ b/migrations/20210623091731-nps-psc-charging-permissions.js
@@ -1,53 +1,53 @@
-'use strict';
+'use strict'
 
-var dbm;
-var type;
-var seed;
-var fs = require('fs');
-var path = require('path');
-var Promise;
+let dbm
+let type
+let seed
+const fs = require('fs')
+const path = require('path')
+let Promise
 
 /**
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {
-  dbm = options.dbmigrate;
-  type = dbm.dataType;
-  seed = seedLink;
-  Promise = options.Promise;
-};
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+  Promise = options.Promise
+}
 
-exports.up = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20210623091731-nps-psc-charging-permissions-up.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.up = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20210623091731-nps-psc-charging-permissions-up.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
-exports.down = function(db) {
-  var filePath = path.join(__dirname, 'sqls', '20210623091731-nps-psc-charging-permissions-down.sql');
-  return new Promise( function( resolve, reject ) {
-    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
-      if (err) return reject(err);
-      console.log('received data: ' + data);
+exports.down = function (db) {
+  const filePath = path.join(__dirname, 'sqls', '20210623091731-nps-psc-charging-permissions-down.sql')
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err)
+      console.log('received data: ' + data)
 
-      resolve(data);
-    });
+      resolve(data)
+    })
   })
-  .then(function(data) {
-    return db.runSql(data);
-  });
-};
+    .then(function (data) {
+      return db.runSql(data)
+    })
+}
 
 exports._meta = {
-  "version": 1
-};
+  version: 1
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,14 +34,9 @@
         "codecov": "^3.8.3",
         "db-migrate": "^0.11.13",
         "db-migrate-pg": "^1.2.2",
-        "eslint": "^8.13.0",
-        "eslint-config-standard": "^14.1.1",
-        "eslint-plugin-import": "^2.26.0",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-promise": "^6.0.0",
-        "eslint-plugin-standard": "^5.0.0",
         "sinon": "^12.0.1",
-        "snyk": "^1.852.0"
+        "snyk": "^1.852.0",
+        "standard": "^17.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2398,7 +2393,7 @@
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
     "node_modules/@types/minimatch": {
@@ -2544,14 +2539,14 @@
       }
     },
     "node_modules/array-includes": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5",
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       },
@@ -2591,6 +2586,24 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
       "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz",
+      "integrity": "sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -2864,6 +2877,30 @@
       "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
+    },
+    "node_modules/builtins/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/cache-base": {
@@ -3593,18 +3630,29 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
     "node_modules/es-abstract": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-      "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
@@ -3616,9 +3664,10 @@
         "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "regexp.prototype.flags": "^1.4.3",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
+        "unbox-primitive": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3772,16 +3821,53 @@
       }
     },
     "node_modules/eslint-config-standard": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
-      "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
+      "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "peerDependencies": {
-        "eslint": ">=6.2.2",
-        "eslint-plugin-import": ">=2.18.0",
-        "eslint-plugin-node": ">=9.1.0",
-        "eslint-plugin-promise": ">=4.2.1",
-        "eslint-plugin-standard": ">=4.0.0"
+        "eslint": "^8.0.1",
+        "eslint-plugin-import": "^2.25.2",
+        "eslint-plugin-n": "^15.0.0",
+        "eslint-plugin-promise": "^6.0.0"
+      }
+    },
+    "node_modules/eslint-config-standard-jsx": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-11.0.0.tgz",
+      "integrity": "sha512-+1EV/R0JxEK1L0NGolAr8Iktm3Rgotx3BKwgaX+eAuSX8D952LULKtjgZD3F+e6SvibONnhLwoTi9DPxN5LvvQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peerDependencies": {
+        "eslint": "^8.8.0",
+        "eslint-plugin-react": "^7.28.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -3826,9 +3912,9 @@
       }
     },
     "node_modules/eslint-plugin-es": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
-      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
       "dev": true,
       "dependencies": {
         "eslint-utils": "^2.0.0",
@@ -3919,51 +4005,47 @@
     "node_modules/eslint-plugin-import/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
-    "node_modules/eslint-plugin-node": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
-      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+    "node_modules/eslint-plugin-n": {
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.2.4.tgz",
+      "integrity": "sha512-tjnVMv2fiXYMnuiIFI8QMtyUFI42SckEEWvi8h68SWGWshfqO6SSCASy24dGMGAiy7NUk6DZt90DM0iNUsmQ5w==",
       "dev": true,
       "dependencies": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
+        "builtins": "^5.0.1",
+        "eslint-plugin-es": "^4.1.0",
+        "eslint-utils": "^3.0.0",
         "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
+        "is-core-module": "^2.9.0",
+        "minimatch": "^3.1.2",
         "resolve": "^1.10.1",
-        "semver": "^6.1.0"
+        "semver": "^7.3.7"
       },
       "engines": {
-        "node": ">=8.10.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=5.16.0"
-      }
-    },
-    "node_modules/eslint-plugin-node/node_modules/eslint-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=12.22.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
-    "node_modules/eslint-plugin-node/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+    "node_modules/eslint-plugin-n/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-promise": {
@@ -3978,28 +4060,70 @@
         "eslint": "^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/eslint-plugin-standard": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz",
-      "integrity": "sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==",
-      "deprecated": "standard 16.0.0 and eslint-config-standard 16.0.0 no longer require the eslint-plugin-standard package. You can remove it from your dependencies with 'npm rm eslint-plugin-standard'. More info here: https://github.com/standard/standard/issues/1316",
+    "node_modules/eslint-plugin-react": {
+      "version": "7.30.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.30.1.tgz",
+      "integrity": "sha512-NbEvI9jtqO46yJA3wcRF9Mo0lF9T/jhdHqhCHXiXtD+Zcb98812wvokjWpU7Q4QH5edo6dmqrukxVvWWXHlsUg==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
+      "dependencies": {
+        "array-includes": "^3.1.5",
+        "array.prototype.flatmap": "^1.3.0",
+        "doctrine": "^2.1.0",
+        "estraverse": "^5.3.0",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.1",
+        "object.values": "^1.1.5",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.3",
+        "semver": "^6.3.0",
+        "string.prototype.matchall": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
       "peerDependencies": {
-        "eslint": ">=5.0.0"
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
+      "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-scope": {
@@ -4608,7 +4732,7 @@
     "node_modules/find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
       "dev": true,
       "dependencies": {
         "locate-path": "^2.0.0"
@@ -4687,10 +4811,37 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -4711,17 +4862,29 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -4829,6 +4992,12 @@
         "moment": "^2.18.1"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
+    },
     "node_modules/handlebars": {
       "version": "4.7.7",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
@@ -4919,9 +5088,9 @@
       }
     },
     "node_modules/has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5279,6 +5448,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
     "node_modules/is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -5325,9 +5500,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -5614,6 +5789,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
     "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
@@ -5689,6 +5870,19 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.1.tgz",
+      "integrity": "sha512-pxrjmNpeRw5wwVeWyEAk7QJu2GnBO3uzPFmHCKJJFPKK2Cy0cWL23krGtLdnMmbIi6/FjlrQpPyfQI19ByPOhQ==",
+      "dev": true,
+      "dependencies": {
+        "array-includes": "^3.1.5",
+        "object.assign": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/just-extend": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
@@ -5735,10 +5929,35 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/load-json-file": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+      "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.15",
+        "parse-json": "^4.0.0",
+        "pify": "^4.0.1",
+        "strip-bom": "^3.0.0",
+        "type-fest": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/load-json-file/node_modules/type-fest": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
       "dev": true,
       "dependencies": {
         "p-locate": "^2.0.0",
@@ -5817,6 +6036,18 @@
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
       "dev": true
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -6106,6 +6337,15 @@
         "node": "*"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -6185,9 +6425,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6226,6 +6466,50 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+      "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
+      "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.hasown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.1.tgz",
+      "integrity": "sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6318,7 +6602,7 @@
     "node_modules/p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
       "dev": true,
       "dependencies": {
         "p-limit": "^1.1.0"
@@ -6330,7 +6614,7 @@
     "node_modules/p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -6374,6 +6658,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "dev": true,
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/pascalcase": {
@@ -6625,6 +6922,80 @@
         "node": ">=6"
       }
     },
+    "node_modules/pkg-conf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^3.0.0",
+        "load-json-file": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pkg-up": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
@@ -6782,6 +7153,17 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -6866,6 +7248,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
+    },
     "node_modules/read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -6907,6 +7295,23 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/regexpp": {
@@ -7659,6 +8064,71 @@
         "node": "*"
       }
     },
+    "node_modules/standard": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-17.0.0.tgz",
+      "integrity": "sha512-GlCM9nzbLUkr+TYR5I2WQoIah4wHA2lMauqbyPLV/oI5gJxqhHzhjl9EG2N0lr/nRqI3KCbCvm/W3smxvLaChA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "eslint": "^8.13.0",
+        "eslint-config-standard": "17.0.0",
+        "eslint-config-standard-jsx": "^11.0.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-n": "^15.1.0",
+        "eslint-plugin-promise": "^6.0.0",
+        "eslint-plugin-react": "^7.28.0",
+        "standard-engine": "^15.0.0"
+      },
+      "bin": {
+        "standard": "bin/cmd.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/standard-engine": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-15.0.0.tgz",
+      "integrity": "sha512-4xwUhJNo1g/L2cleysUqUv7/btn7GEbYJvmgKrQ2vd/8pkTmN8cpqAZg+BT8Z1hNeEH787iWUdOpL8fmApLtxA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "get-stdin": "^8.0.0",
+        "minimist": "^1.2.6",
+        "pkg-conf": "^3.1.0",
+        "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -7810,27 +8280,48 @@
         "node": ">=8"
       }
     },
-    "node_modules/string.prototype.trimend": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
+      "integrity": "sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1",
+        "get-intrinsic": "^1.1.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "regexp.prototype.flags": "^1.4.1",
+        "side-channel": "^1.0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7851,7 +8342,7 @@
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -8202,14 +8693,14 @@
       }
     },
     "node_modules/unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       },
       "funding": {
@@ -8529,6 +9020,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/xtend": {
@@ -10615,7 +11115,7 @@
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
     "@types/minimatch": {
@@ -10719,14 +11219,14 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-includes": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5",
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       }
@@ -10751,6 +11251,18 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
       "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
+      }
+    },
+    "array.prototype.flatmap": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz",
+      "integrity": "sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -10959,6 +11471,26 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
       "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
+    },
+    "builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "requires": {
+        "semver": "^7.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
     },
     "cache-base": {
       "version": "1.0.1",
@@ -11527,18 +12059,29 @@
         "ansi-colors": "^4.1.1"
       }
     },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
     "es-abstract": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-      "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
@@ -11550,9 +12093,10 @@
         "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "regexp.prototype.flags": "^1.4.3",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
+        "unbox-primitive": "^1.0.2"
       }
     },
     "es-shim-unscopables": {
@@ -11763,9 +12307,16 @@
       }
     },
     "eslint-config-standard": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
-      "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
+      "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
+      "dev": true,
+      "requires": {}
+    },
+    "eslint-config-standard-jsx": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-11.0.0.tgz",
+      "integrity": "sha512-+1EV/R0JxEK1L0NGolAr8Iktm3Rgotx3BKwgaX+eAuSX8D952LULKtjgZD3F+e6SvibONnhLwoTi9DPxN5LvvQ==",
       "dev": true,
       "requires": {}
     },
@@ -11812,9 +12363,9 @@
       }
     },
     "eslint-plugin-es": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
-      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
       "dev": true,
       "requires": {
         "eslint-utils": "^2.0.0",
@@ -11880,39 +12431,35 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         }
       }
     },
-    "eslint-plugin-node": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
-      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+    "eslint-plugin-n": {
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.2.4.tgz",
+      "integrity": "sha512-tjnVMv2fiXYMnuiIFI8QMtyUFI42SckEEWvi8h68SWGWshfqO6SSCASy24dGMGAiy7NUk6DZt90DM0iNUsmQ5w==",
       "dev": true,
       "requires": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
+        "builtins": "^5.0.1",
+        "eslint-plugin-es": "^4.1.0",
+        "eslint-utils": "^3.0.0",
         "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
+        "is-core-module": "^2.9.0",
+        "minimatch": "^3.1.2",
         "resolve": "^1.10.1",
-        "semver": "^6.1.0"
+        "semver": "^7.3.7"
       },
       "dependencies": {
-        "eslint-utils": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
           "dev": true,
           "requires": {
-            "eslint-visitor-keys": "^1.1.0"
+            "lru-cache": "^6.0.0"
           }
-        },
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
         }
       }
     },
@@ -11923,12 +12470,55 @@
       "dev": true,
       "requires": {}
     },
-    "eslint-plugin-standard": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz",
-      "integrity": "sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==",
+    "eslint-plugin-react": {
+      "version": "7.30.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.30.1.tgz",
+      "integrity": "sha512-NbEvI9jtqO46yJA3wcRF9Mo0lF9T/jhdHqhCHXiXtD+Zcb98812wvokjWpU7Q4QH5edo6dmqrukxVvWWXHlsUg==",
       "dev": true,
-      "requires": {}
+      "requires": {
+        "array-includes": "^3.1.5",
+        "array.prototype.flatmap": "^1.3.0",
+        "doctrine": "^2.1.0",
+        "estraverse": "^5.3.0",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.5",
+        "object.fromentries": "^2.0.5",
+        "object.hasown": "^1.1.1",
+        "object.values": "^1.1.5",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.3",
+        "semver": "^6.3.0",
+        "string.prototype.matchall": "^4.0.7"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "2.0.0-next.4",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
+          "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.9.0",
+            "path-parse": "^1.0.7",
+            "supports-preserve-symlinks-flag": "^1.0.0"
+          }
+        }
+      }
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -12316,7 +12906,7 @@
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
       "dev": true,
       "requires": {
         "locate-path": "^2.0.0"
@@ -12377,10 +12967,28 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      }
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+    },
+    "functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -12395,15 +13003,21 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       }
+    },
+    "get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+      "dev": true
     },
     "get-symbol-description": {
       "version": "1.0.0",
@@ -12486,6 +13100,12 @@
         "moment": "^2.18.1"
       }
     },
+    "graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
+    },
     "handlebars": {
       "version": "4.7.7",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
@@ -12554,9 +13174,9 @@
       }
     },
     "has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true
     },
     "has-flag": {
@@ -12827,6 +13447,12 @@
         "kind-of": "^6.0.0"
       }
     },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
     "is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -12858,9 +13484,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -13063,6 +13689,12 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
@@ -13124,6 +13756,16 @@
         "verror": "1.10.0"
       }
     },
+    "jsx-ast-utils": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.1.tgz",
+      "integrity": "sha512-pxrjmNpeRw5wwVeWyEAk7QJu2GnBO3uzPFmHCKJJFPKK2Cy0cWL23krGtLdnMmbIi6/FjlrQpPyfQI19ByPOhQ==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.5",
+        "object.assign": "^4.1.2"
+      }
+    },
     "just-extend": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
@@ -13164,10 +13806,31 @@
         "type-check": "~0.4.0"
       }
     },
+    "load-json-file": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+      "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.15",
+        "parse-json": "^4.0.0",
+        "pify": "^4.0.1",
+        "strip-bom": "^3.0.0",
+        "type-fest": "^0.3.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+          "dev": true
+        }
+      }
+    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
       "dev": true,
       "requires": {
         "p-locate": "^2.0.0",
@@ -13243,6 +13906,15 @@
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
       "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -13456,6 +14128,12 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true
+    },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -13518,9 +14196,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true
     },
     "object-keys": {
@@ -13547,6 +14225,38 @@
         "define-properties": "^1.1.3",
         "has-symbols": "^1.0.1",
         "object-keys": "^1.1.1"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+      "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
+      "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      }
+    },
+    "object.hasown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.1.tgz",
+      "integrity": "sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "object.pick": {
@@ -13615,7 +14325,7 @@
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
       "dev": true,
       "requires": {
         "p-limit": "^1.1.0"
@@ -13624,7 +14334,7 @@
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "dev": true
     },
     "packet-reader": {
@@ -13654,6 +14364,16 @@
       "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
       "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
       "dev": true
+    },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      }
     },
     "pascalcase": {
       "version": "0.1.1",
@@ -13847,6 +14567,61 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
     },
+    "pkg-conf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0",
+        "load-json-file": "^5.2.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        }
+      }
+    },
     "pkg-up": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
@@ -13958,6 +14733,17 @@
         "winston": "2.x"
       }
     },
+    "prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -14018,6 +14804,12 @@
         }
       }
     },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
+    },
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -14050,6 +14842,17 @@
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
       }
     },
     "regexpp": {
@@ -14612,6 +15415,34 @@
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
+    "standard": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-17.0.0.tgz",
+      "integrity": "sha512-GlCM9nzbLUkr+TYR5I2WQoIah4wHA2lMauqbyPLV/oI5gJxqhHzhjl9EG2N0lr/nRqI3KCbCvm/W3smxvLaChA==",
+      "dev": true,
+      "requires": {
+        "eslint": "^8.13.0",
+        "eslint-config-standard": "17.0.0",
+        "eslint-config-standard-jsx": "^11.0.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-n": "^15.1.0",
+        "eslint-plugin-promise": "^6.0.0",
+        "eslint-plugin-react": "^7.28.0",
+        "standard-engine": "^15.0.0"
+      }
+    },
+    "standard-engine": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-15.0.0.tgz",
+      "integrity": "sha512-4xwUhJNo1g/L2cleysUqUv7/btn7GEbYJvmgKrQ2vd/8pkTmN8cpqAZg+BT8Z1hNeEH787iWUdOpL8fmApLtxA==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^8.0.0",
+        "minimist": "^1.2.6",
+        "pkg-conf": "^3.1.0",
+        "xdg-basedir": "^4.0.0"
+      }
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -14727,24 +15558,42 @@
         "strip-ansi": "^6.0.1"
       }
     },
-    "string.prototype.trimend": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+    "string.prototype.matchall": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
+      "integrity": "sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1",
+        "get-intrinsic": "^1.1.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "regexp.prototype.flags": "^1.4.1",
+        "side-channel": "^1.0.4"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "strip-ansi": {
@@ -14759,7 +15608,7 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true
     },
     "strip-json-comments": {
@@ -15030,14 +15879,14 @@
       "optional": true
     },
     "unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
     },
@@ -15309,6 +16158,12 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -14,28 +14,13 @@
     "migrate": "node scripts/create-schema && db-migrate up --verbose",
     "migrate:down": "db-migrate down --verbose",
     "migrate:create": "db-migrate create --sql-file --",
-    "lint": "eslint .",
+    "lint": "standard",
+    "lint:fix": "standard --fix",
     "codecov": "codecov",
     "version": "auto-changelog -p --commit-limit false && git add CHANGELOG.md"
   },
   "author": "",
   "license": "ISC",
-  "devDependencies": {
-    "@hapi/code": "^8.0.7",
-    "@hapi/lab": "^24.5.1",
-    "auto-changelog": "^1.16.4",
-    "codecov": "^3.8.3",
-    "db-migrate": "^0.11.13",
-    "db-migrate-pg": "^1.2.2",
-    "eslint": "^8.13.0",
-    "eslint-config-standard": "^14.1.1",
-    "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^6.0.0",
-    "eslint-plugin-standard": "^5.0.0",
-    "sinon": "^12.0.1",
-    "snyk": "^1.852.0"
-  },
   "dependencies": {
     "@envage/hapi-pg-rest-api": "^7.0.0",
     "@envage/water-abstraction-helpers": "4.8.0",
@@ -54,5 +39,16 @@
     "request": "^2.88.2",
     "request-promise-native": "^1.0.9",
     "uuid": "^8.3.2"
+  },
+  "devDependencies": {
+    "@hapi/code": "^8.0.7",
+    "@hapi/lab": "^24.5.1",
+    "auto-changelog": "^1.16.4",
+    "codecov": "^3.8.3",
+    "db-migrate": "^0.11.13",
+    "db-migrate-pg": "^1.2.2",
+    "sinon": "^12.0.1",
+    "snyk": "^1.852.0",
+    "standard": "^17.0.0"
   }
 }

--- a/scripts/create-schema.js
+++ b/scripts/create-schema.js
@@ -1,10 +1,10 @@
-require('dotenv').config();
-const { pool } = require('../src/lib/connectors/db');
+require('dotenv').config()
+const { pool } = require('../src/lib/connectors/db')
 
 async function run () {
-  const { error } = await pool.query('CREATE SCHEMA IF NOT EXISTS idm;');
-  console.log(error || 'OK');
-  process.exit(error ? 1 : 0);
+  const { error } = await pool.query('CREATE SCHEMA IF NOT EXISTS idm;')
+  console.log(error || 'OK')
+  process.exit(error ? 1 : 0)
 }
 
-run();
+run()

--- a/src/controllers/kpi-reports.js
+++ b/src/controllers/kpi-reports.js
@@ -1,11 +1,11 @@
-const HAPIRestAPI = require('@envage/hapi-pg-rest-api');
+const HAPIRestAPI = require('@envage/hapi-pg-rest-api')
 
 module.exports = (config = {}) => {
-  const { pool, version } = config;
+  const { pool, version } = config
   return new HAPIRestAPI({
     table: 'idm.kpi_view',
     endpoint: '/idm/' + version + '/kpi',
     connection: pool,
     validation: {}
-  });
-};
+  })
+}

--- a/src/controllers/status.js
+++ b/src/controllers/status.js
@@ -1,8 +1,8 @@
-const pkg = require('../../package.json');
-const { pick } = require('lodash');
+const pkg = require('../../package.json')
+const { pick } = require('lodash')
 
-const statusResponse = pick(pkg, 'version');
+const statusResponse = pick(pkg, 'version')
 
-const getStatus = () => statusResponse;
+const getStatus = () => statusResponse
 
-exports.getStatus = getStatus;
+exports.getStatus = getStatus

--- a/src/controllers/user-roles.js
+++ b/src/controllers/user-roles.js
@@ -1,28 +1,28 @@
-const repos = require('../lib/repos');
-const Boom = require('@hapi/boom');
-const usersRepo = repos.usersRepo;
-const { omit } = require('lodash');
+const repos = require('../lib/repos')
+const Boom = require('@hapi/boom')
+const usersRepo = repos.usersRepo
+const { omit } = require('lodash')
 
 const putUserRoles = async (request) => {
-  const { userId } = request.params;
-  const { application, roles, groups } = request.payload;
+  const { userId } = request.params
+  const { application, roles, groups } = request.payload
 
-  const user = await usersRepo.findById(userId);
+  const user = await usersRepo.findById(userId)
 
   if (!user) {
-    return Boom.notFound(`User with id ${userId} does not exist`);
+    return Boom.notFound(`User with id ${userId} does not exist`)
   }
 
   // clean out the old mappings and replace with the new set
-  await usersRepo.deleteRoles(userId);
+  await usersRepo.deleteRoles(userId)
   await Promise.all([
     usersRepo.createRoles(userId, application, roles),
     usersRepo.createGroups(userId, application, groups)
-  ]);
+  ])
 
   // include the updated user in the response
-  const updatedUser = await usersRepo.findUserWithRoles(userId);
-  return { error: null, data: omit(updatedUser, 'password') };
-};
+  const updatedUser = await usersRepo.findUserWithRoles(userId)
+  return { error: null, data: omit(updatedUser, 'password') }
+}
 
-exports.putUserRoles = putUserRoles;
+exports.putUserRoles = putUserRoles

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -1,12 +1,12 @@
-const HAPIRestAPI = require('@envage/hapi-pg-rest-api');
-const Joi = require('joi');
-const { omit } = require('lodash');
+const HAPIRestAPI = require('@envage/hapi-pg-rest-api')
+const Joi = require('joi')
+const { omit } = require('lodash')
 
-const { createHash } = require('../lib/helpers');
+const { createHash } = require('../lib/helpers')
 
-const { usersRepo } = require('../lib/repos');
-const { pool } = require('../lib/connectors/db');
-const { version } = require('../../config');
+const { usersRepo } = require('../lib/repos')
+const { pool } = require('../lib/connectors/db')
+const { version } = require('../../config')
 
 const restApi = new HAPIRestAPI({
   table: 'idm.users',
@@ -18,22 +18,22 @@ const restApi = new HAPIRestAPI({
   postSelect: (data) => {
     return data.map(row => {
       // Don't include password in returned data
-      const { password, ...rest } = row;
-      return rest;
-    });
+      const { password, ...rest } = row
+      return rest
+    })
   },
   preQuery: async (request) => {
     // Hash passwords found in data
     if ('password' in request.data) {
-      request.data.password = await createHash(request.data.password);
+      request.data.password = await createHash(request.data.password)
     }
     if ('user_data' in request.data && typeof request.data.user_data !== 'string') {
-      request.data.user_data = JSON.stringify(request.data.user_data);
+      request.data.user_data = JSON.stringify(request.data.user_data)
     }
     if ('role' in request.data && typeof request.data.role !== 'string') {
-      request.data.role = JSON.stringify(request.data.role);
+      request.data.role = JSON.stringify(request.data.role)
     }
-    return request;
+    return request
   },
   onCreateTimestamp: 'date_created',
   onUpdateTimestamp: 'date_updated',
@@ -54,7 +54,7 @@ const restApi = new HAPIRestAPI({
     external_id: Joi.string().allow(null),
     enabled: Joi.boolean()
   }
-});
+})
 
 /**
  * Override find one handler
@@ -63,18 +63,18 @@ const restApi = new HAPIRestAPI({
  * @return {Promise}         [description]
  */
 restApi.routes.findOneRoute.handler = async (request, h) => {
-  const { id } = request.params;
+  const { id } = request.params
 
-  const user = await usersRepo.findUserWithRoles(id);
+  const user = await usersRepo.findUserWithRoles(id)
 
   if (user) {
-    return { error: null, data: omit(user, 'password') };
+    return { error: null, data: omit(user, 'password') }
   }
 
   return h.response({
     error: 'User not found',
     data: null
-  }).code(404);
-};
+  }).code(404)
+}
 
-module.exports = restApi.getRoutes();
+module.exports = restApi.getRoutes()

--- a/src/lib/connectors/db.js
+++ b/src/lib/connectors/db.js
@@ -1,7 +1,7 @@
-require('dotenv').config();
-const helpers = require('@envage/water-abstraction-helpers');
+require('dotenv').config()
+const helpers = require('@envage/water-abstraction-helpers')
 
-const config = require('../../../config.js');
-const { logger } = require('../../logger');
+const config = require('../../../config.js')
+const { logger } = require('../../logger')
 
-exports.pool = helpers.db.createPool(config.pg, logger);
+exports.pool = helpers.db.createPool(config.pg, logger)

--- a/src/lib/connectors/notify.js
+++ b/src/lib/connectors/notify.js
@@ -1,10 +1,10 @@
-const Water = require('./water');
-const { logger } = require('../../logger');
-const { application } = require('../../../config');
+const Water = require('./water')
+const { logger } = require('../../logger')
+const { application } = require('../../../config')
 
 const getPasswordResetUrl = (resetGuid, userApplication) => {
-  return `${application[userApplication]}/reset_password_change_password?resetGuid=${resetGuid}`;
-};
+  return `${application[userApplication]}/reset_password_change_password?resetGuid=${resetGuid}`
+}
 
 /**
  * @TODO remove this and make Notify emails consistent instead
@@ -19,30 +19,30 @@ const getPasswordResetUrl = (resetGuid, userApplication) => {
  * @return {Object} personalisation for notify
  */
 function mapNotifyPersonalisation (params, mode) {
-  const { loginUrl, resetUrl, createUrl, shareUrl, firstName, sender } = params;
+  const { loginUrl, resetUrl, createUrl, shareUrl, firstName, sender } = params
 
   if (mode === 'new') {
     return {
       link: createUrl
-    };
+    }
   }
   if (mode === 'existing') {
     return {
       link: loginUrl,
       resetLink: resetUrl
-    };
+    }
   }
   if (mode === 'reset') {
     return {
       firstname: firstName,
       reset_url: resetUrl
-    };
+    }
   }
   if (mode === 'sharing') {
     return {
       link: shareUrl,
       sender
-    };
+    }
   }
 }
 
@@ -56,7 +56,7 @@ function mapNotifyPersonalisation (params, mode) {
  * @
  */
 function sendPasswordResetEmail (params, mode = 'reset') {
-  const { email, resetGuid, firstName, sender, userApplication } = params;
+  const { email, resetGuid, firstName, sender, userApplication } = params
   const personalisation = {
     firstName,
     resetUrl: getPasswordResetUrl(resetGuid, userApplication),
@@ -64,40 +64,40 @@ function sendPasswordResetEmail (params, mode = 'reset') {
     shareUrl: `${application.water_vml}/create-password?resetGuid=${resetGuid}&utm_source=system&utm_medium=email&utm_campaign=share_access`,
     loginUrl: `${application.water_vml}/signin?utm_source=system&utm_medium=email&utm_campaign=send_login`,
     sender
-  };
+  }
   const messageRefs = {
     reset: 'password_reset_email',
     new: 'new_user_verification_email',
     existing: 'existing_user_verification_email',
     sharing: 'share_new_user'
-  };
-  return Water.sendNotifyMessage(messageRefs[mode], email, mapNotifyPersonalisation(personalisation, mode));
+  }
+  return Water.sendNotifyMessage(messageRefs[mode], email, mapNotifyPersonalisation(personalisation, mode))
 }
 
 function sendPasswordLockEmail (params) {
   return new Promise((resolve, reject) => {
-    logger.info(params);
+    logger.info(params)
 
     const personalisation = {
       reset_url: getPasswordResetUrl(params.resetGuid, params.userApplication),
       firstname: params.firstName
-    };
+    }
 
-    const emailAddress = params.email;
+    const emailAddress = params.email
 
     Water.sendNotifyMessage('password_locked_email', emailAddress, personalisation)
       .then((response) => {
-        resolve(true);
+        resolve(true)
       })
       .catch((err) => {
-        logger.error('Error occurred sending notify email');
-        logger.error(err.message);
-        reject(err);
-      });
-  });
+        logger.error('Error occurred sending notify email')
+        logger.error(err.message)
+        reject(err)
+      })
+  })
 }
 
 module.exports = {
-  sendPasswordResetEmail: sendPasswordResetEmail,
-  sendPasswordLockEmail: sendPasswordLockEmail
-};
+  sendPasswordResetEmail,
+  sendPasswordLockEmail
+}

--- a/src/lib/connectors/water.js
+++ b/src/lib/connectors/water.js
@@ -1,6 +1,6 @@
-const helpers = require('@envage/water-abstraction-helpers');
-const { logger } = require('../../../src/logger');
-const config = require('../../../config');
+const helpers = require('@envage/water-abstraction-helpers')
+const { logger } = require('../../../src/logger')
+const config = require('../../../config')
 
 /**
  * Sends a notify message, this is used in the the event of a password lock
@@ -11,14 +11,14 @@ const config = require('../../../config');
  */
 const sendNotifyMessage = async (messageRef, recipient, personalisation = {}) => {
   try {
-    const uri = `${config.services.water}/notify/${messageRef}`;
-    const options = { body: { recipient, personalisation } };
-    const response = await helpers.serviceRequest.post(uri, options);
-    return response;
+    const uri = `${config.services.water}/notify/${messageRef}`
+    const options = { body: { recipient, personalisation } }
+    const response = await helpers.serviceRequest.post(uri, options)
+    return response
   } catch (err) {
-    logger.error('Error sending notify message', err);
-    throw err;
+    logger.error('Error sending notify message', err)
+    throw err
   }
-};
+}
 
-exports.sendNotifyMessage = sendNotifyMessage;
+exports.sendNotifyMessage = sendNotifyMessage

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -1,21 +1,21 @@
-const bcrypt = require('bcryptjs');
+const bcrypt = require('bcryptjs')
 
-const util = require('util');
+const util = require('util')
 
 function createHash (string) {
   return new Promise((resolve, reject) => {
     bcrypt.genSalt(10, function (saltErr, salt) {
       if (saltErr) {
-        reject(saltErr);
+        reject(saltErr)
       }
       bcrypt.hash(string, salt, function (hashErr, hash) {
         if (hashErr) {
-          reject(hashErr);
+          reject(hashErr)
         }
-        resolve(hash);
-      });
-    });
-  });
+        resolve(hash)
+      })
+    })
+  })
 }
 
 /**
@@ -24,11 +24,11 @@ function createHash (string) {
  * @return {String} - the random code
  */
 const createDigitCode = (length = 6) => {
-  const addFactor = Math.pow(10, length - 1);
-  const multiplyBy = addFactor * 9;
+  const addFactor = Math.pow(10, length - 1)
+  const multiplyBy = addFactor * 9
 
-  return Math.floor(addFactor + Math.random() * multiplyBy);
-};
+  return Math.floor(addFactor + Math.random() * multiplyBy)
+}
 
 /**
  * Compares password with a hash
@@ -36,10 +36,10 @@ const createDigitCode = (length = 6) => {
  * @param {String} hash
  * @return {Promise<Boolean>} resolves with boolean true if password OK
  */
-const testPassword = util.promisify(bcrypt.compare);
+const testPassword = util.promisify(bcrypt.compare)
 
 module.exports = {
   createHash,
   createDigitCode,
   testPassword
-};
+}

--- a/src/lib/repos/change-email.js
+++ b/src/lib/repos/change-email.js
@@ -1,5 +1,5 @@
-const Repository = require('@envage/hapi-pg-rest-api/src/repository');
-const { createDigitCode } = require('../helpers');
+const Repository = require('@envage/hapi-pg-rest-api/src/repository')
+const { createDigitCode } = require('../helpers')
 
 class ChangeEmailRepository extends Repository {
   /**
@@ -11,10 +11,10 @@ class ChangeEmailRepository extends Repository {
     const query = `
       SELECT * FROM idm.email_change WHERE user_id=$1
         AND reference_date=CURRENT_DATE
-    `;
-    const params = [userId];
-    const { rows: [row] } = await this.dbQuery(query, params);
-    return row;
+    `
+    const params = [userId]
+    const { rows: [row] } = await this.dbQuery(query, params)
+    return row
   }
 
   /**
@@ -32,29 +32,29 @@ class ChangeEmailRepository extends Repository {
         VALUES (gen_random_uuid(), $1, $2, $3, CURRENT_DATE, NOW(), NOW(), 1, 0) ON CONFLICT (user_id, reference_date) DO UPDATE SET new_email_address=EXCLUDED.new_email_address,
           security_code=EXCLUDED.security_code,
           date_updated=NOW(), attempts=email_change.attempts+1
-          WHERE email_change.date_verified IS NULL RETURNING *;`;
-    const securityCode = createDigitCode();
-    const params = [userId, newEmail, securityCode];
-    const { rows: [row] } = await this.dbQuery(query, params);
-    return row;
+          WHERE email_change.date_verified IS NULL RETURNING *;`
+    const securityCode = createDigitCode()
+    const params = [userId, newEmail, securityCode]
+    const { rows: [row] } = await this.dbQuery(query, params)
+    return row
   }
 
   async incrementSecurityCodeAttempts (userId) {
     const query = `UPDATE idm.email_change
           SET security_code_attempts=security_code_attempts+1
-          WHERE user_id=$1 AND reference_date=CURRENT_DATE;`;
-    const params = [userId];
-    return this.dbQuery(query, params);
+          WHERE user_id=$1 AND reference_date=CURRENT_DATE;`
+    const params = [userId]
+    return this.dbQuery(query, params)
   }
 
   async updateVerified (userId, securityCode) {
     const query = `UPDATE idm.email_change
           SET date_verified=NOW()
           WHERE user_id=$1 AND reference_date=CURRENT_DATE
-          AND security_code=$2;`;
-    const params = [userId, securityCode];
-    return this.dbQuery(query, params);
+          AND security_code=$2;`
+    const params = [userId, securityCode]
+    return this.dbQuery(query, params)
   }
 }
 
-module.exports = ChangeEmailRepository;
+module.exports = ChangeEmailRepository

--- a/src/lib/repos/date-helpers.js
+++ b/src/lib/repos/date-helpers.js
@@ -1,10 +1,10 @@
-const moment = require('moment');
+const moment = require('moment')
 
 const getYesterday = refDate =>
-  moment(refDate).subtract(1, 'days').format();
+  moment(refDate).subtract(1, 'days').format()
 
 const getNow = refDate =>
-  moment(refDate).format();
+  moment(refDate).format()
 
-exports.getYesterday = getYesterday;
-exports.getNow = getNow;
+exports.getYesterday = getYesterday
+exports.getNow = getNow

--- a/src/lib/repos/index.js
+++ b/src/lib/repos/index.js
@@ -1,26 +1,26 @@
-const UsersRepository = require('./users');
-const ChangeEmailRepository = require('./change-email');
-const ReauthenticationRepository = require('./reauthentication');
-const { pool } = require('../../lib/connectors/db');
+const UsersRepository = require('./users')
+const ChangeEmailRepository = require('./change-email')
+const ReauthenticationRepository = require('./reauthentication')
+const { pool } = require('../../lib/connectors/db')
 
 const usersRepo = new UsersRepository({
   connection: pool,
   table: 'idm.users',
   primaryKey: 'user_id'
-});
+})
 
 const changeEmailRepo = new ChangeEmailRepository({
   connection: pool,
   table: 'idm.email_change_verification',
   primaryKey: 'email_change_verification_id'
-});
+})
 
 const reauthRepo = new ReauthenticationRepository({
   connection: pool
-});
+})
 
 module.exports = {
   usersRepo,
   changeEmailRepo,
   reauthRepo
-};
+}

--- a/src/lib/repos/reauthentication.js
+++ b/src/lib/repos/reauthentication.js
@@ -1,6 +1,6 @@
 class ReauthenticationRepository {
   constructor (config) {
-    this.connection = config.connection;
+    this.connection = config.connection
   }
 
   /**
@@ -12,10 +12,10 @@ class ReauthenticationRepository {
   async findByUserId (userId) {
     const query = `INSERT INTO idm.reauthentication
         (reauthentication_id, user_id, reference_date, date_created, date_updated, attempts)
-        VALUES (gen_random_uuid(), $1, CURRENT_DATE, NOW(), NOW(), 0) ON CONFLICT (user_id, reference_date) DO UPDATE SET date_updated=NOW(), attempts=reauthentication.attempts+1 RETURNING *;`;
-    const params = [userId];
-    const { rows: [record] } = await this.connection.query(query, params);
-    return record;
+        VALUES (gen_random_uuid(), $1, CURRENT_DATE, NOW(), NOW(), 0) ON CONFLICT (user_id, reference_date) DO UPDATE SET date_updated=NOW(), attempts=reauthentication.attempts+1 RETURNING *;`
+    const params = [userId]
+    const { rows: [record] } = await this.connection.query(query, params)
+    return record
   }
 
   /**
@@ -25,10 +25,10 @@ class ReauthenticationRepository {
   resetAttemptCounter (userId) {
     const query = `UPDATE idm.reauthentication
         SET attempts=0, date_updated=NOW()
-        WHERE user_id=$1 AND reference_date=CURRENT_DATE;`;
-    const params = [userId];
-    return this.connection.query(query, params);
+        WHERE user_id=$1 AND reference_date=CURRENT_DATE;`
+    const params = [userId]
+    return this.connection.query(query, params)
   }
 };
 
-module.exports = ReauthenticationRepository;
+module.exports = ReauthenticationRepository

--- a/src/lib/repos/users.js
+++ b/src/lib/repos/users.js
@@ -1,9 +1,9 @@
-const Repository = require('@envage/hapi-pg-rest-api/src/repository');
+const Repository = require('@envage/hapi-pg-rest-api/src/repository')
 
-const { getNow } = require('./date-helpers');
+const { getNow } = require('./date-helpers')
 
-const mapRole = row => row.role;
-const mapGroup = row => row.group;
+const mapRole = row => row.role
+const mapGroup = row => row.group
 
 /**
  * Repository for idm.users table
@@ -16,8 +16,8 @@ class UsersRepository extends Repository {
    * @return {Promise<Object>}
    */
   async findById (userId) {
-    const { rows: [user] } = await this.find({ user_id: userId });
-    return user;
+    const { rows: [user] } = await this.find({ user_id: userId })
+    return user
   }
 
   async findGroups (userId) {
@@ -26,10 +26,10 @@ class UsersRepository extends Repository {
       from idm.groups g
         join idm.user_groups ug on ug.group_id = g.group_id
       where ug.user_id = $1;
-    `;
+    `
 
-    const { rows } = await this.dbQuery(query, [userId]);
-    return rows.map(mapGroup);
+    const { rows } = await this.dbQuery(query, [userId])
+    return rows.map(mapGroup)
   }
 
   /**
@@ -53,9 +53,9 @@ class UsersRepository extends Repository {
       from idm.user_roles ur
         join idm.roles r on ur.role_id = r.role_id
       where ur.user_id = $1;
-    `;
-    const { rows } = await this.dbQuery(query, [userId]);
-    return rows.map(mapRole);
+    `
+    const { rows } = await this.dbQuery(query, [userId])
+    return rows.map(mapRole)
   }
 
   /**
@@ -66,7 +66,7 @@ class UsersRepository extends Repository {
    * @return {Promise<Object>}       - returns user if found
    */
   async findInSameApplication (userId, newEmail) {
-    const email = newEmail.trim().toLowerCase();
+    const email = newEmail.trim().toLowerCase()
 
     const query = `SELECT * FROM idm.users u
       JOIN (
@@ -74,12 +74,12 @@ class UsersRepository extends Repository {
           FROM idm.users u
           WHERE u.user_id=$1
       ) u2 ON u.application=u2.application
-      WHERE u.user_name=$2`;
+      WHERE u.user_name=$2`
 
-    const params = [userId, email];
+    const params = [userId, email]
 
-    const { rows: [user] } = await this.dbQuery(query, params);
-    return user;
+    const { rows: [user] } = await this.dbQuery(query, params)
+    return user
   }
 
   /**
@@ -89,13 +89,13 @@ class UsersRepository extends Repository {
    * @return {Promise<Object>} - user record
    */
   async updateEmailAddress (userId, newEmail, refDate) {
-    const filter = { user_id: userId };
+    const filter = { user_id: userId }
     const data = {
       user_name: newEmail.toLowerCase().trim(),
       date_updated: getNow(refDate)
-    };
-    const { rows: [user] } = await this.update(filter, data);
-    return user;
+    }
+    const { rows: [user] } = await this.update(filter, data)
+    return user
   }
 
   /** Deletes all role and groups associations for the given user id
@@ -103,13 +103,13 @@ class UsersRepository extends Repository {
    * @param {Number} userId The id of the user whose roles and groups are to be deleted
    */
   deleteRoles (userId) {
-    const rolesQuery = 'delete from idm.user_roles where user_id = $1';
-    const groupsQuery = 'delete from idm.user_groups where user_id = $1';
+    const rolesQuery = 'delete from idm.user_roles where user_id = $1'
+    const groupsQuery = 'delete from idm.user_groups where user_id = $1'
 
     return Promise.all([
       this.dbQuery(rolesQuery, [userId]),
       this.dbQuery(groupsQuery, [userId])
-    ]);
+    ])
   }
 
   /**
@@ -127,9 +127,9 @@ class UsersRepository extends Repository {
       select gen_random_uuid(), $1, r.role_id
       from idm.roles r
       where r.application = $2
-      and r.role = any ($3);`;
+      and r.role = any ($3);`
 
-    return this.dbQuery(query, [userId, application, roles]);
+    return this.dbQuery(query, [userId, application, roles])
   }
 
   /**
@@ -147,9 +147,9 @@ class UsersRepository extends Repository {
       select gen_random_uuid(), $1, g.group_id
       from idm.groups g
       where g.application = $2
-      and g.group = any ($3);`;
+      and g.group = any ($3);`
 
-    return this.dbQuery(query, [userId, application, groups]);
+    return this.dbQuery(query, [userId, application, groups])
   }
 
   async findUserWithRoles (userId) {
@@ -157,14 +157,14 @@ class UsersRepository extends Repository {
       this.findById(userId),
       this.findRoles(userId),
       this.findGroups(userId)
-    ]);
+    ])
 
     if (user) {
-      user.roles = roles;
-      user.groups = groups;
+      user.roles = roles
+      user.groups = groups
     }
 
-    return user;
+    return user
   }
 
   /**
@@ -178,10 +178,10 @@ class UsersRepository extends Repository {
       select *
       from idm.users
       where lower(user_name) = lower($1)
-      and application = $2;`;
-    const params = [userName, application];
-    const { rows: [user] } = await this.dbQuery(query, params);
-    return user;
+      and application = $2;`
+    const params = [userName, application]
+    const { rows: [user] } = await this.dbQuery(query, params)
+    return user
   }
 
   /**
@@ -195,10 +195,10 @@ class UsersRepository extends Repository {
         SET bad_logins = COALESCE(bad_logins, 0) + 1, date_updated = NOW()
         WHERE user_id=$1
         RETURNING *
-    `;
-    const params = [userId];
-    const { rows: [user] } = await this.dbQuery(query, params);
-    return user;
+    `
+    const params = [userId]
+    const { rows: [user] } = await this.dbQuery(query, params)
+    return user
   }
 
   /**
@@ -213,9 +213,9 @@ class UsersRepository extends Repository {
       UPDATE idm.users
         SET password = 'VOID', reset_guid = $2, date_updated = NOW()
         WHERE user_id = $1
-    `;
-    const params = [userId, resetGuid];
-    return this.dbQuery(query, params);
+    `
+    const params = [userId, resetGuid]
+    return this.dbQuery(query, params)
   }
 
   /**
@@ -225,7 +225,7 @@ class UsersRepository extends Repository {
    * @return {Promise}            resolves when reset GUID is updated
    */
   updateResetGuid (userId, resetGuid) {
-    return this.update({ user_id: userId }, { reset_guid: resetGuid });
+    return this.update({ user_id: userId }, { reset_guid: resetGuid })
   }
 
   /**
@@ -241,10 +241,10 @@ class UsersRepository extends Repository {
       last_login = now(),
       date_updated = now()
       where user_id = $1
-      returning *;`;
-    const params = [userId];
-    const { rows: [user] } = await this.dbQuery(query, params);
-    return user;
+      returning *;`
+    const params = [userId]
+    const { rows: [user] } = await this.dbQuery(query, params)
+    return user
   };
 
   /**
@@ -265,10 +265,10 @@ class UsersRepository extends Repository {
     last_login IS NOT NULL 
     AND date_created IS NOT NULL 
     GROUP BY month, current_year
-    ORDER BY current_year asc, month desc;`;
-    const { rows } = await this.dbQuery(query);
-    return rows;
+    ORDER BY current_year asc, month desc;`
+    const { rows } = await this.dbQuery(query)
+    return rows
   };
 };
 
-module.exports = UsersRepository;
+module.exports = UsersRepository

--- a/src/lib/slack.js
+++ b/src/lib/slack.js
@@ -1,14 +1,14 @@
 // contains generic functions unrelated to a specific component
 const rp = require('request-promise-native').defaults({
   strictSSL: false
-});
+})
 
-const { logger } = require('../logger');
+const { logger } = require('../logger')
 
 function post (message) {
   return new Promise((resolve, reject) => {
-    const uri = 'https://hooks.slack.com/services/' + process.env.SLACK_HOOK;
-    logger.info(uri);
+    const uri = 'https://hooks.slack.com/services/' + process.env.SLACK_HOOK
+    logger.info(uri)
     const options = {
       method: 'POST',
       url: uri,
@@ -18,14 +18,14 @@ function post (message) {
       form: {
         payload: '{"channel": "#beta-activity", "username": "Gerald The Water Buffalo", "text": "' + message + '", "icon_emoji": ":water_buffalo:"}'
       }
-    };
+    }
 
     rp(options)
       .then(() => resolve('yay'))
-      .catch(err => reject(err));
-  });
+      .catch(err => reject(err))
+  })
 }
 
 module.exports = {
   post
-};
+}

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,6 +1,6 @@
-const config = require('../config');
-const { createLogger } = require('@envage/water-abstraction-helpers').logger;
+const config = require('../config')
+const { createLogger } = require('@envage/water-abstraction-helpers').logger
 
-const logger = createLogger(config.logger);
+const logger = createLogger(config.logger)
 
-exports.logger = logger;
+exports.logger = logger

--- a/src/modules/acceptance-tests/controller.js
+++ b/src/modules/acceptance-tests/controller.js
@@ -1,6 +1,6 @@
-const { pool } = require('../../lib/connectors/db');
-const ACCEPTANCE_TEST_SOURCE = 'acceptance-test-setup';
-const config = require('../../../config');
+const { pool } = require('../../lib/connectors/db')
+const ACCEPTANCE_TEST_SOURCE = 'acceptance-test-setup'
+const config = require('../../../config')
 
 const deleteAcceptanceTestData = async (request, h) => {
   await pool.query(`
@@ -8,11 +8,11 @@ const deleteAcceptanceTestData = async (request, h) => {
     from idm.users
     where user_data->>'source' = '${ACCEPTANCE_TEST_SOURCE}' 
     or user_name like '%@example.com';
-  `);
+  `)
 
-  return h.response().code(204);
-};
+  return h.response().code(204)
+}
 
 if (config.isAcceptanceTestTarget) {
-  exports.deleteAcceptanceTestData = deleteAcceptanceTestData;
+  exports.deleteAcceptanceTestData = deleteAcceptanceTestData
 }

--- a/src/modules/acceptance-tests/routes.js
+++ b/src/modules/acceptance-tests/routes.js
@@ -1,5 +1,5 @@
-const config = require('../../../config');
-const controller = require('./controller');
+const config = require('../../../config')
+const controller = require('./controller')
 
 if (config.isAcceptanceTestTarget) {
   exports.acceptanceTestTearDown = {
@@ -9,5 +9,5 @@ if (config.isAcceptanceTestTarget) {
     options: {
       description: 'Deletes any data setup for acceptance test execution'
     }
-  };
+  }
 }

--- a/src/modules/authenticate/routes.js
+++ b/src/modules/authenticate/routes.js
@@ -1,6 +1,6 @@
-const Joi = require('joi');
-const controller = require('./controller');
-const { version } = require('../../../config');
+const Joi = require('joi')
+const controller = require('./controller')
+const { version } = require('../../../config')
 
 module.exports = [
   {
@@ -18,4 +18,4 @@ module.exports = [
       }
     }
   }
-];
+]

--- a/src/modules/change-email/controller.js
+++ b/src/modules/change-email/controller.js
@@ -1,14 +1,14 @@
-const repos = require('../../lib/repos');
-const Boom = require('@hapi/boom');
-const { get } = require('lodash');
+const repos = require('../../lib/repos')
+const Boom = require('@hapi/boom')
+const { get } = require('lodash')
 
 const isRateLimitExceeded = row =>
-  get(row, 'attempts') >= 3 || get(row, 'security_code_attempts') >= 3;
+  get(row, 'attempts') >= 3 || get(row, 'security_code_attempts') >= 3
 
 const isVerified = row =>
-  get(row, 'date_verified', null) !== null;
+  get(row, 'date_verified', null) !== null
 
-const isLocked = row => isRateLimitExceeded(row) || isVerified(row);
+const isLocked = row => isRateLimitExceeded(row) || isVerified(row)
 
 /**
  * If the error is a Boom error, return a { data, error } response and
@@ -19,21 +19,21 @@ const isLocked = row => isRateLimitExceeded(row) || isVerified(row);
  */
 const errorHandler = (error, h) => {
   if (error.isBoom) {
-    console.log(error.message);
-    return h.response({ data: null, error: error.message }).code(error.output.statusCode);
+    console.log(error.message)
+    return h.response({ data: null, error: error.message }).code(error.output.statusCode)
   }
-  throw error;
-};
+  throw error
+}
 
 /**
  * Gets status of email change process
  */
 const getStatus = async (request, h) => {
-  const { userId } = request.params;
+  const { userId } = request.params
   try {
-    const data = await repos.changeEmailRepo.findOneByUserId(userId);
+    const data = await repos.changeEmailRepo.findOneByUserId(userId)
     if (!data) {
-      throw Boom.notFound(`No email change record found for user ${userId}`);
+      throw Boom.notFound(`No email change record found for user ${userId}`)
     }
     return {
       data: {
@@ -42,43 +42,43 @@ const getStatus = async (request, h) => {
         isLocked: isLocked(data)
       },
       error: null
-    };
+    }
   } catch (err) {
-    return errorHandler(err, h);
+    return errorHandler(err, h)
   }
-};
+}
 
 const validateEmailChange = (userId, emailChange) => {
   if (isRateLimitExceeded(emailChange)) {
-    throw Boom.tooManyRequests(`User ${userId} - too many email change attempts`);
+    throw Boom.tooManyRequests(`User ${userId} - too many email change attempts`)
   }
 
   if (isVerified(emailChange)) {
-    throw Boom.locked(`User ${userId} - already verified`);
+    throw Boom.locked(`User ${userId} - already verified`)
   }
-};
+}
 
 /**
  * Starts email change process
  */
 const postStartEmailChange = async (request, h) => {
-  const { userId } = request.params;
-  const { email } = request.payload;
+  const { userId } = request.params
+  const { email } = request.payload
 
   try {
     // Rate limit requests
-    const existing = await repos.changeEmailRepo.findOneByUserId(userId);
+    const existing = await repos.changeEmailRepo.findOneByUserId(userId)
 
-    validateEmailChange(userId, existing);
+    validateEmailChange(userId, existing)
 
     // Upsert email change record
-    const data = await repos.changeEmailRepo.create(userId, email);
+    const data = await repos.changeEmailRepo.create(userId, email)
 
     // Check for an existing user with the new email address
     const existingUser = await repos.usersRepo
-      .findInSameApplication(userId, email);
+      .findInSameApplication(userId, email)
     if (existingUser) {
-      throw Boom.conflict(`User ${userId} - ${email} already exists`);
+      throw Boom.conflict(`User ${userId} - ${email} already exists`)
     }
 
     return {
@@ -87,40 +87,40 @@ const postStartEmailChange = async (request, h) => {
         securityCode: data.security_code
       },
       error: null
-    };
+    }
   } catch (err) {
-    return errorHandler(err, h);
+    return errorHandler(err, h)
   }
-};
+}
 
 /**
  * Completes email change process
  */
 const postSecurityCode = async (request, h) => {
-  const { userId } = request.params;
-  const { securityCode } = request.payload;
+  const { userId } = request.params
+  const { securityCode } = request.payload
 
   try {
-    await repos.changeEmailRepo.incrementSecurityCodeAttempts(userId);
+    await repos.changeEmailRepo.incrementSecurityCodeAttempts(userId)
 
     // Rate limit requests to 3 per day
-    const existing = await repos.changeEmailRepo.findOneByUserId(userId);
+    const existing = await repos.changeEmailRepo.findOneByUserId(userId)
 
     if (!existing) {
-      throw Boom.notFound(`User ${userId} - no record found, may have expired`);
+      throw Boom.notFound(`User ${userId} - no record found, may have expired`)
     }
 
-    validateEmailChange(userId, existing);
+    validateEmailChange(userId, existing)
 
     if (securityCode !== existing.security_code) {
-      throw Boom.unauthorized(`User ${userId} - wrong security code`);
+      throw Boom.unauthorized(`User ${userId} - wrong security code`)
     }
 
     // Update verified status of email change record
-    await repos.changeEmailRepo.updateVerified(userId, securityCode);
+    await repos.changeEmailRepo.updateVerified(userId, securityCode)
 
     // Update the user
-    const user = await repos.usersRepo.updateEmailAddress(userId, existing.new_email_address);
+    const user = await repos.usersRepo.updateEmailAddress(userId, existing.new_email_address)
 
     return {
       data: {
@@ -128,14 +128,14 @@ const postSecurityCode = async (request, h) => {
         email: user.user_name
       },
       error: null
-    };
+    }
   } catch (err) {
-    return errorHandler(err, h);
+    return errorHandler(err, h)
   }
-};
+}
 
 module.exports = {
   postStartEmailChange,
   postSecurityCode,
   getStatus
-};
+}

--- a/src/modules/change-email/routes.js
+++ b/src/modules/change-email/routes.js
@@ -1,12 +1,12 @@
-const Joi = require('joi');
-const { version } = require('../../../config');
-const controller = require('./controller');
+const Joi = require('joi')
+const { version } = require('../../../config')
+const controller = require('./controller')
 
-const SECURITY_CODE_REGEX = /^[0-9]{6}$/;
+const SECURITY_CODE_REGEX = /^[0-9]{6}$/
 
-const VALID_USER_ID = Joi.number().positive().required();
-const VALID_SECURITY_CODE = Joi.string().regex(SECURITY_CODE_REGEX).required();
-const VALID_EMAIL = Joi.string().email().required();
+const VALID_USER_ID = Joi.number().positive().required()
+const VALID_SECURITY_CODE = Joi.string().regex(SECURITY_CODE_REGEX).required()
+const VALID_EMAIL = Joi.string().email().required()
 
 module.exports = [{
   method: 'POST',
@@ -54,4 +54,4 @@ module.exports = [{
   }
 }
 
-];
+]

--- a/src/modules/kpi-reporting/controller.js
+++ b/src/modules/kpi-reporting/controller.js
@@ -1,6 +1,6 @@
-const repos = require('../../lib/repos');
-const Boom = require('@hapi/boom');
-const { mapRegistrations } = require('./lib/mapper');
+const repos = require('../../lib/repos')
+const Boom = require('@hapi/boom')
+const { mapRegistrations } = require('./lib/mapper')
 
 /**
  * Registrations KPI data for KPI UI for the service
@@ -10,14 +10,14 @@ const { mapRegistrations } = require('./lib/mapper');
  * application for all time then broken down by month for the current year
  */
 const getRegistrations = async (request, h) => {
-  const repoData = await repos.usersRepo.findRegistrationsByMonth();
+  const repoData = await repos.usersRepo.findRegistrationsByMonth()
   if (!repoData) {
-    return Boom.notFound('No data found from users table');
+    return Boom.notFound('No data found from users table')
   }
-  const data = mapRegistrations(repoData);
-  return { data };
-};
+  const data = mapRegistrations(repoData)
+  return { data }
+}
 
 module.exports = {
   getRegistrations
-};
+}

--- a/src/modules/kpi-reporting/lib/mapper.js
+++ b/src/modules/kpi-reporting/lib/mapper.js
@@ -1,8 +1,8 @@
-'use-strict';
-const { omit } = require('lodash');
+'use-strict'
+const { omit } = require('lodash')
 
 const months = ['January', 'February', 'March', 'April', 'May', 'June',
-  'July', 'August', 'September', 'October', 'November', 'December'];
+  'July', 'August', 'September', 'October', 'November', 'December']
 
 /**
  * Sums the total number of registrations in all rows and for those in the current year
@@ -10,13 +10,13 @@ const months = ['January', 'February', 'March', 'April', 'May', 'June',
  * @return {Number}
  */
 const mapRegistrations = rows => rows.reduce((acc, row) => {
-  const year = (new Date()).getFullYear();
-  acc.totals.allTime = acc.totals.allTime + row.internal + row.external;
-  acc.totals.ytd = acc.totals.ytd + (row.current_year ? row.internal + row.external : 0);
+  const year = (new Date()).getFullYear()
+  acc.totals.allTime = acc.totals.allTime + row.internal + row.external
+  acc.totals.ytd = acc.totals.ytd + (row.current_year ? row.internal + row.external : 0)
   if (row.current_year) {
-    acc.monthly.push({ ...(omit(row, 'current_year')), month: months[row.month - 1], year });
+    acc.monthly.push({ ...(omit(row, 'current_year')), month: months[row.month - 1], year })
   }
-  return acc;
-}, { totals: { allTime: 0, ytd: 0 }, monthly: [] });
+  return acc
+}, { totals: { allTime: 0, ytd: 0 }, monthly: [] })
 
-exports.mapRegistrations = mapRegistrations;
+exports.mapRegistrations = mapRegistrations

--- a/src/modules/kpi-reporting/routes.js
+++ b/src/modules/kpi-reporting/routes.js
@@ -1,5 +1,5 @@
-const { version } = require('../../../config');
-const controller = require('./controller');
+const { version } = require('../../../config')
+const controller = require('./controller')
 
 module.exports = [{
   method: 'GET',
@@ -8,4 +8,4 @@ module.exports = [{
   options: {
     description: 'Gets KPI data for user registrations by month'
   }
-}];
+}]

--- a/src/modules/reauthentication/controller.js
+++ b/src/modules/reauthentication/controller.js
@@ -1,6 +1,6 @@
-const repos = require('../../lib/repos');
-const Boom = require('@hapi/boom');
-const helpers = require('../../lib/helpers');
+const repos = require('../../lib/repos')
+const Boom = require('@hapi/boom')
+const helpers = require('../../lib/helpers')
 
 /**
  * If the error is a Boom error, return a { data, error } response and
@@ -11,47 +11,47 @@ const helpers = require('../../lib/helpers');
  */
 const errorHandler = (error, h) => {
   if (error.isBoom) {
-    return h.response({ data: null, error: error.message }).code(error.output.statusCode);
+    return h.response({ data: null, error: error.message }).code(error.output.statusCode)
   }
-  throw error;
-};
+  throw error
+}
 
 /**
  * @param {Number} request.params.userId
  * @param {String} request.payload.password
  */
 const postReauthenticate = async (request, h) => {
-  const { userId } = request.params;
-  const { password } = request.payload;
+  const { userId } = request.params
+  const { password } = request.payload
 
   try {
     // Find user
-    const user = await repos.usersRepo.findById(userId);
+    const user = await repos.usersRepo.findById(userId)
 
     if (!user) {
-      throw Boom.notFound(`User ${userId} not found`);
+      throw Boom.notFound(`User ${userId} not found`)
     }
 
     // Find reauth record for user ID today
-    const reauth = await repos.reauthRepo.findByUserId(userId);
+    const reauth = await repos.reauthRepo.findByUserId(userId)
 
     // Limit attempts per day
     if (reauth.attempts > 10) {
-      throw Boom.tooManyRequests(`Too many reauthentication attempts - user ${userId}`);
+      throw Boom.tooManyRequests(`Too many reauthentication attempts - user ${userId}`)
     }
 
     // Check submitted password
-    const isAuthenticated = await helpers.testPassword(password, user.password);
+    const isAuthenticated = await helpers.testPassword(password, user.password)
 
     if (isAuthenticated) {
-      await repos.reauthRepo.resetAttemptCounter(userId);
-      return { data: { userId }, error: null };
+      await repos.reauthRepo.resetAttemptCounter(userId)
+      return { data: { userId }, error: null }
     }
 
-    throw Boom.unauthorized(`Incorrect password - user ${userId}`);
+    throw Boom.unauthorized(`Incorrect password - user ${userId}`)
   } catch (err) {
-    return errorHandler(err, h);
+    return errorHandler(err, h)
   }
-};
+}
 
-exports.postReauthenticate = postReauthenticate;
+exports.postReauthenticate = postReauthenticate

--- a/src/modules/reauthentication/routes.js
+++ b/src/modules/reauthentication/routes.js
@@ -1,9 +1,9 @@
 
-const Joi = require('joi');
-const controller = require('./controller');
+const Joi = require('joi')
+const controller = require('./controller')
 
-const VALID_USER_ID = Joi.number().positive().required();
-const VALID_PASSWORD = Joi.string().required();
+const VALID_USER_ID = Joi.number().positive().required()
+const VALID_PASSWORD = Joi.string().required()
 
 module.exports = [
   {
@@ -22,4 +22,4 @@ module.exports = [
       }
     }
   }
-];
+]

--- a/src/routes/idm.js
+++ b/src/routes/idm.js
@@ -1,18 +1,18 @@
 /* API operations only - NO UI */
-const Joi = require('joi');
-const { version } = require('../../config');
-const { pool } = require('../lib/connectors/db');
+const Joi = require('joi')
+const { version } = require('../../config')
+const { pool } = require('../lib/connectors/db')
 const apiConfig = {
   pool,
   version
-};
+}
 
-const resetController = require('../controllers/reset');
-const usersRoutes = require('../controllers/user');
-const KpiApi = require('../controllers/kpi-reports.js')(apiConfig);
-const statusController = require('../controllers/status');
-const userRolesRoutes = require('./user-roles');
-const acceptanceTestsRoutes = require('../modules/acceptance-tests/routes');
+const resetController = require('../controllers/reset')
+const usersRoutes = require('../controllers/user')
+const KpiApi = require('../controllers/kpi-reports.js')(apiConfig)
+const statusController = require('../controllers/status')
+const userRolesRoutes = require('./user-roles')
+const acceptanceTestsRoutes = require('../modules/acceptance-tests/routes')
 
 module.exports = [
   {
@@ -55,4 +55,4 @@ module.exports = [
   ...userRolesRoutes,
   ...Object.values(acceptanceTestsRoutes),
   ...require('../modules/kpi-reporting/routes')
-];
+]

--- a/src/routes/user-roles.js
+++ b/src/routes/user-roles.js
@@ -1,6 +1,6 @@
-const Joi = require('joi');
-const { version } = require('../../config');
-const controller = require('../controllers/user-roles');
+const Joi = require('joi')
+const { version } = require('../../config')
+const controller = require('../controllers/user-roles')
 
 module.exports = [
   {
@@ -20,4 +20,4 @@ module.exports = [
       }
     }
   }
-];
+]

--- a/test/auth.js
+++ b/test/auth.js
@@ -7,18 +7,18 @@
  * - Verify with auth code
  * - Update documents with verification ID to verified status
  */
-'use strict';
-const { v4: uuid } = require('uuid');
-const { experiment, test, before, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const { deleteTestUsers } = require('./test-helpers');
+'use strict'
+const { v4: uuid } = require('uuid')
+const { experiment, test, before, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const { deleteTestUsers } = require('./test-helpers')
 
-const { expect } = require('@hapi/code');
-const server = require('../index');
+const { expect } = require('@hapi/code')
+const server = require('../index')
 
-let createdEmails = [];
+let createdEmails = []
 
 async function createUser (email, password, application = 'water_vml') {
-  createdEmails.push(email);
+  createdEmails.push(email)
 
   const request = {
     method: 'POST',
@@ -32,19 +32,19 @@ async function createUser (email, password, application = 'water_vml') {
         unitTest: true
       })
     }
-  };
+  }
 
-  const res = await server.inject(request);
-  expect(res.statusCode).to.equal(201);
+  const res = await server.inject(request)
+  expect(res.statusCode).to.equal(201)
 
   // Check payload
-  const payload = JSON.parse(res.payload);
+  const payload = JSON.parse(res.payload)
 
-  expect(payload.error).to.equal(null);
-  expect(payload.data.user_id).to.be.a.number();
+  expect(payload.error).to.equal(null)
+  expect(payload.data.user_id).to.be.a.number()
 
   // Return user ID for future tests
-  return payload.data.user_id;
+  return payload.data.user_id
 }
 
 async function getUser (userId) {
@@ -52,10 +52,10 @@ async function getUser (userId) {
     method: 'GET',
     url: `/idm/1.0/user/${userId}`,
     headers: { Authorization: process.env.JWT_TOKEN }
-  };
+  }
 
-  const res = await server.inject(request);
-  return res.result.data;
+  const res = await server.inject(request)
+  return res.result.data
 }
 
 const buildRequest = (email, password, application) => ({
@@ -69,98 +69,98 @@ const buildRequest = (email, password, application) => ({
     password,
     application
   }
-});
+})
 
 experiment('Test authentication API', () => {
   before(async () => {
-    await deleteTestUsers();
-  });
+    await deleteTestUsers()
+  })
 
   beforeEach(async ({ context }) => {
-    createdEmails = [];
-    context.email = 'unit-test-user@example.com';
-    context.password = uuid();
-    context.application = 'water_vml';
-    context.userId = await createUser(context.email, context.password, context.application);
-  });
+    createdEmails = []
+    context.email = 'unit-test-user@example.com'
+    context.password = uuid()
+    context.application = 'water_vml'
+    context.userId = await createUser(context.email, context.password, context.application)
+  })
 
   afterEach(async () => {
-    await deleteTestUsers();
-  });
+    await deleteTestUsers()
+  })
 
   test('The API should allow authentication with correct password', async ({ context }) => {
-    const { email, password, application } = context;
-    const request = buildRequest(email, password, application);
-    const res = await server.inject(request);
-    expect(res.statusCode).to.equal(200);
+    const { email, password, application } = context
+    const request = buildRequest(email, password, application)
+    const res = await server.inject(request)
+    expect(res.statusCode).to.equal(200)
 
     // Check payload
-    const payload = JSON.parse(res.payload);
+    const payload = JSON.parse(res.payload)
 
-    expect(payload.err).to.equal(null);
-    expect(payload.user_id).to.equal(context.userId);
-  });
+    expect(payload.err).to.equal(null)
+    expect(payload.user_id).to.equal(context.userId)
+  })
 
   test('The API should ensure passwords are case sensitive', async ({ context }) => {
-    const { email, password, application } = context;
-    const request = buildRequest(email, password.toUpperCase(), application);
+    const { email, password, application } = context
+    const request = buildRequest(email, password.toUpperCase(), application)
 
-    const res = await server.inject(request);
-    expect(res.statusCode).to.equal(401);
+    const res = await server.inject(request)
+    expect(res.statusCode).to.equal(401)
 
     // Check payload
-    const payload = JSON.parse(res.payload);
+    const payload = JSON.parse(res.payload)
 
-    expect(payload.err).to.not.equal(null);
-  });
+    expect(payload.err).to.not.equal(null)
+  })
 
   test('The API should allow authentication for admin user with admin account', async () => {
     // create a water_admin user
-    const email = 'unit-test-admin@example.com';
-    const password = uuid();
-    const application = 'water_admin';
+    const email = 'unit-test-admin@example.com'
+    const password = uuid()
+    const application = 'water_admin'
 
-    const userId = await createUser(email, password, application);
+    const userId = await createUser(email, password, application)
 
-    const request = buildRequest(email, password, application);
+    const request = buildRequest(email, password, application)
 
-    const res = await server.inject(request);
-    expect(res.statusCode).to.equal(200);
+    const res = await server.inject(request)
+    expect(res.statusCode).to.equal(200)
 
     // Check payload
-    const payload = JSON.parse(res.payload);
+    const payload = JSON.parse(res.payload)
 
-    expect(payload.err).to.equal(null);
-    expect(payload.user_id).to.equal(userId);
-  });
+    expect(payload.err).to.equal(null)
+    expect(payload.user_id).to.equal(userId)
+  })
 
   test('The API should prevent authentication with incorrect password', async ({ context }) => {
-    const request = buildRequest(context.email, 'wrongpass', context.application);
-    const res = await server.inject(request);
-    expect(res.statusCode).to.equal(401);
+    const request = buildRequest(context.email, 'wrongpass', context.application)
+    const res = await server.inject(request)
+    expect(res.statusCode).to.equal(401)
 
     // Check payload
-    const payload = JSON.parse(res.payload);
-    expect(payload.err).to.not.equal(null);
-  });
+    const payload = JSON.parse(res.payload)
+    expect(payload.err).to.not.equal(null)
+  })
 
   test('bad_logins is incremented on failed auth attempt', async ({ context }) => {
-    const request = buildRequest(context.email, 'wrongpass', context.application);
-    await server.inject(request);
-    await server.inject(request);
+    const request = buildRequest(context.email, 'wrongpass', context.application)
+    await server.inject(request)
+    await server.inject(request)
 
-    const user = await getUser(context.userId);
-    expect(user.bad_logins).to.equal('2');
-  });
+    const user = await getUser(context.userId)
+    expect(user.bad_logins).to.equal('2')
+  })
 
   test('A user cannot use credentials for a different application', async ({ context }) => {
-    const request = buildRequest(context.email, context.password, 'water_admin');
-    const res = await server.inject(request);
-    expect(res.statusCode).to.equal(401);
+    const request = buildRequest(context.email, context.password, 'water_admin')
+    const res = await server.inject(request)
+    expect(res.statusCode).to.equal(401)
 
     // Check payload
-    const payload = JSON.parse(res.payload);
+    const payload = JSON.parse(res.payload)
 
-    expect(payload.err).to.not.equal(null);
-  });
-});
+    expect(payload.err).to.not.equal(null)
+  })
+})

--- a/test/config.js
+++ b/test/config.js
@@ -1,49 +1,49 @@
-const { test, experiment, before, after } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+const { test, experiment, before, after } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
 function requireUncached (module) {
-  delete require.cache[require.resolve(module)];
-  return require(module);
+  delete require.cache[require.resolve(module)]
+  return require(module)
 }
 
 experiment('config.js', () => {
-  const originalTestMode = process.env.TEST_MODE;
+  const originalTestMode = process.env.TEST_MODE
 
   after(async () => {
-    process.env.TEST_MODE = originalTestMode;
-  });
+    process.env.TEST_MODE = originalTestMode
+  })
 
   experiment('when test mode is enabled', () => {
-    let config;
+    let config
 
     before(async () => {
-      process.env.TEST_MODE = '1';
-      config = requireUncached('../config.js');
-    });
+      process.env.TEST_MODE = '1'
+      config = requireUncached('../config.js')
+    })
 
     test('logging level is "info"', async () => {
-      expect(config.logger.level).to.equal('info');
-    });
+      expect(config.logger.level).to.equal('info')
+    })
 
     test('default application base url for external service', async () => {
-      expect(config.application.water_vml).to.equal('http://127.0.0.1:8000');
-    });
+      expect(config.application.water_vml).to.equal('http://127.0.0.1:8000')
+    })
 
     test('default application base url for internal service', async () => {
-      expect(config.application.water_admin).to.equal('http://127.0.0.1:8008');
-    });
-  });
+      expect(config.application.water_admin).to.equal('http://127.0.0.1:8008')
+    })
+  })
 
   experiment('when test mode is disabled', () => {
-    let config;
+    let config
 
     before(async () => {
-      process.env.TEST_MODE = '0';
-      config = requireUncached('../config.js');
-    });
+      process.env.TEST_MODE = '0'
+      config = requireUncached('../config.js')
+    })
 
     test('logging level is "error"', async () => {
-      expect(config.logger.level).to.equal('error');
-    });
-  });
-});
+      expect(config.logger.level).to.equal('error')
+    })
+  })
+})

--- a/test/controllers/reset.js
+++ b/test/controllers/reset.js
@@ -1,19 +1,19 @@
-const { expect } = require('@hapi/code');
-const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const controller = require('../../src/controllers/reset');
-const sinon = require('sinon');
-const sandbox = sinon.createSandbox();
-const repos = require('../../src/lib/repos');
-const notify = require('../../src/lib/connectors/notify');
-const { v4: uuid } = require('uuid');
-const moment = require('moment');
+const { expect } = require('@hapi/code')
+const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const controller = require('../../src/controllers/reset')
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
+const repos = require('../../src/lib/repos')
+const notify = require('../../src/lib/connectors/notify')
+const { v4: uuid } = require('uuid')
+const moment = require('moment')
 
 const getResponseToolkitStub = () => {
-  const h = {};
-  h.response = sinon.stub().returns(h);
-  h.code = sinon.stub().returns(h);
-  return h;
-};
+  const h = {}
+  h.response = sinon.stub().returns(h)
+  h.code = sinon.stub().returns(h)
+  return h
+}
 
 const getRequest = email => {
   return {
@@ -23,107 +23,107 @@ const getRequest = email => {
       email
     },
     log: () => {}
-  };
-};
+  }
+}
 
-const guidRegex = /[\d|\w]{8}-[\d|\w]{4}-[\d|\w]{4}-[\d|\w]{4}-[\d|\w]{12}/;
+const guidRegex = /[\d|\w]{8}-[\d|\w]{4}-[\d|\w]{4}-[\d|\w]{4}-[\d|\w]{12}/
 
 experiment('resetPassword', () => {
   beforeEach(async () => {
-    sandbox.stub(repos.usersRepo, 'findByUsername');
-    sandbox.stub(repos.usersRepo, 'updateResetGuid').resolves({});
-    sandbox.stub(notify, 'sendPasswordResetEmail').resolves({});
-  });
+    sandbox.stub(repos.usersRepo, 'findByUsername')
+    sandbox.stub(repos.usersRepo, 'updateResetGuid').resolves({})
+    sandbox.stub(notify, 'sendPasswordResetEmail').resolves({})
+  })
 
-  afterEach(async () => sandbox.restore());
+  afterEach(async () => sandbox.restore())
 
   test('returns a 404 for an unknown user', async () => {
-    repos.usersRepo.findByUsername.resolves();
+    repos.usersRepo.findByUsername.resolves()
 
-    const request = getRequest('nope@example.com');
-    const h = getResponseToolkitStub();
+    const request = getRequest('nope@example.com')
+    const h = getResponseToolkitStub()
 
-    await controller.resetPassword(request, h);
+    await controller.resetPassword(request, h)
 
-    expect(h.code.args[0][0]).to.equal(404);
-    expect(h.response.args[0][0].data).to.be.null();
-    expect(h.response.args[0][0].error.message).to.equal('User not found for email nope@example.com');
-  });
+    expect(h.code.args[0][0]).to.equal(404)
+    expect(h.response.args[0][0].data).to.be.null()
+    expect(h.response.args[0][0].error.message).to.equal('User not found for email nope@example.com')
+  })
 
   test('returns a 404 for a disabled user', async () => {
     repos.usersRepo.findByUsername.resolves({
       user_id: 123,
       user_name: 'test@example.com',
       enabled: false
-    });
+    })
 
-    const request = getRequest('nope@example.com');
-    const h = getResponseToolkitStub();
+    const request = getRequest('nope@example.com')
+    const h = getResponseToolkitStub()
 
-    await controller.resetPassword(request, h);
+    await controller.resetPassword(request, h)
 
-    expect(h.code.args[0][0]).to.equal(404);
-    expect(h.response.args[0][0].data).to.be.null();
-    expect(h.response.args[0][0].error.message).to.equal('User not found for email nope@example.com');
-  });
-});
+    expect(h.code.args[0][0]).to.equal(404)
+    expect(h.response.args[0][0].data).to.be.null()
+    expect(h.response.args[0][0].error.message).to.equal('User not found for email nope@example.com')
+  })
+})
 
 experiment('resetPassword - when reset guid has not been set before', () => {
-  let request;
-  let response;
-  let h;
+  let request
+  let response
+  let h
 
   beforeEach(async () => {
-    sandbox.stub(notify, 'sendPasswordResetEmail').resolves({});
-    sandbox.stub(repos.usersRepo, 'updateResetGuid').resolves({});
+    sandbox.stub(notify, 'sendPasswordResetEmail').resolves({})
+    sandbox.stub(repos.usersRepo, 'updateResetGuid').resolves({})
     sandbox.stub(repos.usersRepo, 'findByUsername').resolves({
       user_id: 123,
       user_name: 'test@example.com',
       enabled: true
-    });
+    })
 
-    request = getRequest('test@example.com');
-    h = getResponseToolkitStub();
+    request = getRequest('test@example.com')
+    h = getResponseToolkitStub()
 
-    response = await controller.resetPassword(request, h);
-  });
+    response = await controller.resetPassword(request, h)
+  })
 
-  afterEach(async () => sandbox.restore());
+  afterEach(async () => sandbox.restore())
 
   test('the reset guid is updated', async () => {
-    expect(repos.usersRepo.updateResetGuid.args[0][0]).to.equal(123);
-    expect(repos.usersRepo.updateResetGuid.args[0][1]).to.match(guidRegex);
-  });
+    expect(repos.usersRepo.updateResetGuid.args[0][0]).to.equal(123)
+    expect(repos.usersRepo.updateResetGuid.args[0][1]).to.match(guidRegex)
+  })
 
   test('a message is sent via notify', async () => {
-    const paramsArg = notify.sendPasswordResetEmail.args[0][0];
-    const mode = notify.sendPasswordResetEmail.args[0][1];
+    const paramsArg = notify.sendPasswordResetEmail.args[0][0]
+    const mode = notify.sendPasswordResetEmail.args[0][1]
 
-    expect(paramsArg.email).to.equal('test@example.com');
-    expect(paramsArg.firstName).to.equal('(User)');
-    expect(paramsArg.resetGuid).to.match(guidRegex);
-    expect(mode).to.equal('reset');
-  });
+    expect(paramsArg.email).to.equal('test@example.com')
+    expect(paramsArg.firstName).to.equal('(User)')
+    expect(paramsArg.resetGuid).to.match(guidRegex)
+    expect(mode).to.equal('reset')
+  })
 
   test('the response has no error', async () => {
-    expect(response.error).to.be.null();
-  });
+    expect(response.error).to.be.null()
+  })
 
   test('the response contains the expected data', async () => {
-    expect(response.data.user_id).to.equal(123);
-    expect(response.data.user_name).to.equal('test@example.com');
-    expect(response.data.reset_guid).to.match(guidRegex);
-  });
-});
+    expect(response.data.user_id).to.equal(123)
+    expect(response.data.user_name).to.equal('test@example.com')
+    expect(response.data.reset_guid).to.match(guidRegex)
+  })
+})
 
 experiment('resetPassword - when reset guid has been updated in the last 24 hours', () => {
-  let request;
-  let response;
-  let resetGuid;
+  let request
+  let response
+  let resetGuid
 
   beforeEach(async () => {
-    resetGuid = uuid();
-    request = getRequest('test@example.com');
+    resetGuid = uuid()
+    request = getRequest('test@example.com')
 
     sandbox.stub(repos.usersRepo, 'findByUsername').resolves({
       user_id: 123,
@@ -131,84 +131,84 @@ experiment('resetPassword - when reset guid has been updated in the last 24 hour
       reset_guid: resetGuid,
       reset_guid_date_created: moment().subtract(5, 'hours').toISOString(),
       enabled: true
-    });
-    sandbox.stub(repos.usersRepo, 'updateResetGuid').resolves({});
-    sandbox.stub(notify, 'sendPasswordResetEmail').resolves({});
+    })
+    sandbox.stub(repos.usersRepo, 'updateResetGuid').resolves({})
+    sandbox.stub(notify, 'sendPasswordResetEmail').resolves({})
 
-    response = await controller.resetPassword(request, getResponseToolkitStub());
-  });
+    response = await controller.resetPassword(request, getResponseToolkitStub())
+  })
 
-  afterEach(async () => sandbox.restore());
+  afterEach(async () => sandbox.restore())
 
   test('the reset guid is not updated', async () => {
-    expect(repos.usersRepo.updateResetGuid.called).to.be.false();
-  });
+    expect(repos.usersRepo.updateResetGuid.called).to.be.false()
+  })
 
   test('a message is sent via notify using the existing reset guid', async () => {
-    const paramsArg = notify.sendPasswordResetEmail.args[0][0];
-    const mode = notify.sendPasswordResetEmail.args[0][1];
+    const paramsArg = notify.sendPasswordResetEmail.args[0][0]
+    const mode = notify.sendPasswordResetEmail.args[0][1]
 
-    expect(paramsArg.email).to.equal('test@example.com');
-    expect(paramsArg.firstName).to.equal('(User)');
-    expect(paramsArg.resetGuid).to.equal(resetGuid);
-    expect(mode).to.equal('reset');
-  });
+    expect(paramsArg.email).to.equal('test@example.com')
+    expect(paramsArg.firstName).to.equal('(User)')
+    expect(paramsArg.resetGuid).to.equal(resetGuid)
+    expect(mode).to.equal('reset')
+  })
 
   test('the response has no error', async () => {
-    expect(response.error).to.be.null();
-  });
+    expect(response.error).to.be.null()
+  })
 
   test('the response contains the expected data', async () => {
-    expect(response.data.user_id).to.equal(123);
-    expect(response.data.user_name).to.equal('test@example.com');
-    expect(response.data.reset_guid).to.match(guidRegex);
-  });
-});
+    expect(response.data.user_id).to.equal(123)
+    expect(response.data.user_name).to.equal('test@example.com')
+    expect(response.data.reset_guid).to.match(guidRegex)
+  })
+})
 
 experiment('resetPassword - when reset guid was last set over 1 day ago', () => {
-  let request;
-  let response;
+  let request
+  let response
 
   beforeEach(async () => {
-    request = getRequest('test@example.com');
+    request = getRequest('test@example.com')
 
-    sandbox.stub(repos.usersRepo, 'updateResetGuid').resolves({});
+    sandbox.stub(repos.usersRepo, 'updateResetGuid').resolves({})
     sandbox.stub(repos.usersRepo, 'findByUsername').resolves({
       user_id: 123,
       user_name: 'test@example.com',
       reset_guid: uuid(),
       reset_guid_date_created: moment().subtract(25, 'hours').toISOString(),
       enabled: true
-    });
-    sandbox.stub(notify, 'sendPasswordResetEmail').resolves({});
+    })
+    sandbox.stub(notify, 'sendPasswordResetEmail').resolves({})
 
-    response = await controller.resetPassword(request, getResponseToolkitStub());
-  });
+    response = await controller.resetPassword(request, getResponseToolkitStub())
+  })
 
-  afterEach(async () => sandbox.restore());
+  afterEach(async () => sandbox.restore())
 
   test('the reset guid is updated', async () => {
-    expect(repos.usersRepo.updateResetGuid.args[0][0]).to.equal(123);
-    expect(repos.usersRepo.updateResetGuid.args[0][1]).to.match(guidRegex);
-  });
+    expect(repos.usersRepo.updateResetGuid.args[0][0]).to.equal(123)
+    expect(repos.usersRepo.updateResetGuid.args[0][1]).to.match(guidRegex)
+  })
 
   test('a message is sent via notify', async () => {
-    const paramsArg = notify.sendPasswordResetEmail.args[0][0];
-    const mode = notify.sendPasswordResetEmail.args[0][1];
+    const paramsArg = notify.sendPasswordResetEmail.args[0][0]
+    const mode = notify.sendPasswordResetEmail.args[0][1]
 
-    expect(paramsArg.email).to.equal('test@example.com');
-    expect(paramsArg.firstName).to.equal('(User)');
-    expect(paramsArg.resetGuid).to.match(guidRegex);
-    expect(mode).to.equal('reset');
-  });
+    expect(paramsArg.email).to.equal('test@example.com')
+    expect(paramsArg.firstName).to.equal('(User)')
+    expect(paramsArg.resetGuid).to.match(guidRegex)
+    expect(mode).to.equal('reset')
+  })
 
   test('the response has no error', async () => {
-    expect(response.error).to.be.null();
-  });
+    expect(response.error).to.be.null()
+  })
 
   test('the response contains the expected data', async () => {
-    expect(response.data.user_id).to.equal(123);
-    expect(response.data.user_name).to.equal('test@example.com');
-    expect(response.data.reset_guid).to.match(guidRegex);
-  });
-});
+    expect(response.data.user_id).to.equal(123)
+    expect(response.data.user_name).to.equal('test@example.com')
+    expect(response.data.reset_guid).to.match(guidRegex)
+  })
+})

--- a/test/controllers/status.js
+++ b/test/controllers/status.js
@@ -1,12 +1,12 @@
-const { test, experiment } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const controller = require('../../src/controllers/status');
+const { test, experiment } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const controller = require('../../src/controllers/status')
 
 experiment('controllers/status', () => {
   experiment('getStatus', () => {
     test('returns an object with the application version', () => {
-      const response = controller.getStatus();
-      expect(response.version).to.match(/^\d*\.\d*\.\d*$/);
-    });
-  });
-});
+      const response = controller.getStatus()
+      expect(response.version).to.match(/^\d*\.\d*\.\d*$/)
+    })
+  })
+})

--- a/test/controllers/user-roles.js
+++ b/test/controllers/user-roles.js
@@ -1,31 +1,31 @@
-const { expect } = require('@hapi/code');
+const { expect } = require('@hapi/code')
 const {
   beforeEach,
   afterEach,
   test,
   experiment
-} = exports.lab = require('@hapi/lab').script();
-const sinon = require('sinon');
-const sandbox = sinon.createSandbox();
+} = exports.lab = require('@hapi/lab').script()
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
 
-const { usersRepo } = require('../../src/lib/repos');
+const { usersRepo } = require('../../src/lib/repos')
 
-const controller = require('../../src/controllers/user-roles');
+const controller = require('../../src/controllers/user-roles')
 
 experiment('controllers/user-roles', () => {
-  let request;
+  let request
 
   beforeEach(async () => {
     sandbox.stub(usersRepo, 'findById').resolves({
       user_id: 123
-    });
-    sandbox.stub(usersRepo, 'createRoles').resolves();
-    sandbox.stub(usersRepo, 'createGroups').resolves();
-    sandbox.stub(usersRepo, 'deleteRoles').resolves();
+    })
+    sandbox.stub(usersRepo, 'createRoles').resolves()
+    sandbox.stub(usersRepo, 'createGroups').resolves()
+    sandbox.stub(usersRepo, 'deleteRoles').resolves()
     sandbox.stub(usersRepo, 'findUserWithRoles').resolves({
       user_id: 123,
       password: 'test-password'
-    });
+    })
 
     request = {
       params: { userId: 123 },
@@ -34,50 +34,50 @@ experiment('controllers/user-roles', () => {
         roles: ['roleA'],
         groups: ['groupA', 'groupB']
       }
-    };
-  });
+    }
+  })
 
-  afterEach(async () => sandbox.restore());
+  afterEach(async () => sandbox.restore())
 
   experiment('.putUserRoles', () => {
     test('returns a 404 if the user does not exist', async () => {
-      usersRepo.findById.resolves();
-      const response = await controller.putUserRoles(request);
+      usersRepo.findById.resolves()
+      const response = await controller.putUserRoles(request)
 
-      expect(response.isBoom).to.be.true();
-      expect(response.output.statusCode).to.equal(404);
-    });
+      expect(response.isBoom).to.be.true()
+      expect(response.output.statusCode).to.equal(404)
+    })
 
     test('deletes any existing roles', async () => {
-      await controller.putUserRoles(request);
-      const [userId] = usersRepo.deleteRoles.lastCall.args;
-      expect(userId).to.equal(123);
-    });
+      await controller.putUserRoles(request)
+      const [userId] = usersRepo.deleteRoles.lastCall.args
+      expect(userId).to.equal(123)
+    })
 
     test('creates the new roles', async () => {
-      await controller.putUserRoles(request);
-      const [userId, application, roles] = usersRepo.createRoles.lastCall.args;
-      expect(userId).to.equal(123);
-      expect(application).to.equal('test-application');
-      expect(roles).to.equal(['roleA']);
-    });
+      await controller.putUserRoles(request)
+      const [userId, application, roles] = usersRepo.createRoles.lastCall.args
+      expect(userId).to.equal(123)
+      expect(application).to.equal('test-application')
+      expect(roles).to.equal(['roleA'])
+    })
 
     test('creates the new groups', async () => {
-      await controller.putUserRoles(request);
-      const [userId, application, groups] = usersRepo.createGroups.lastCall.args;
-      expect(userId).to.equal(123);
-      expect(application).to.equal('test-application');
-      expect(groups).to.equal(['groupA', 'groupB']);
-    });
+      await controller.putUserRoles(request)
+      const [userId, application, groups] = usersRepo.createGroups.lastCall.args
+      expect(userId).to.equal(123)
+      expect(application).to.equal('test-application')
+      expect(groups).to.equal(['groupA', 'groupB'])
+    })
 
     test('returns the updated user excluding the password', async () => {
-      const response = await controller.putUserRoles(request);
+      const response = await controller.putUserRoles(request)
       expect(response).to.equal({
         error: null,
         data: {
           user_id: 123
         }
-      });
-    });
-  });
-});
+      })
+    })
+  })
+})

--- a/test/lib/connectors/notify.js
+++ b/test/lib/connectors/notify.js
@@ -1,37 +1,37 @@
-const { expect } = require('@hapi/code');
-const { beforeEach, afterEach, experiment, test } = exports.lab = require('@hapi/lab').script();
-const sinon = require('sinon');
-const sandbox = sinon.createSandbox();
-const helpers = require('@envage/water-abstraction-helpers');
+const { expect } = require('@hapi/code')
+const { beforeEach, afterEach, experiment, test } = exports.lab = require('@hapi/lab').script()
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
+const helpers = require('@envage/water-abstraction-helpers')
 
-const config = require('../../../config');
-const notify = require('../../../src/lib/connectors/notify');
-const { logger } = require('../../../src/logger');
+const config = require('../../../config')
+const notify = require('../../../src/lib/connectors/notify')
+const { logger } = require('../../../src/logger')
 
-const response = { foo: 'bar' };
+const response = { foo: 'bar' }
 const params = {
   email: 'bob@example.com',
   resetGuid: '123-abc',
   firstName: 'bob',
   sender: 'test-sender',
   userApplication: 'water_vml'
-};
+}
 
 experiment('notify connectors', () => {
   beforeEach(async () => {
-    sandbox.stub(helpers.serviceRequest, 'post').resolves(response);
-    sandbox.stub(logger, 'error');
-  });
+    sandbox.stub(helpers.serviceRequest, 'post').resolves(response)
+    sandbox.stub(logger, 'error')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('sendNotifyMessage', () => {
     test('calls serviceRequest.post with correct arguments', async () => {
-      await notify.sendPasswordResetEmail(params);
-      const [uri, options] = helpers.serviceRequest.post.lastCall.args;
-      expect(uri).to.equal(`${config.services.water}/notify/password_reset_email`);
+      await notify.sendPasswordResetEmail(params)
+      const [uri, options] = helpers.serviceRequest.post.lastCall.args
+      expect(uri).to.equal(`${config.services.water}/notify/password_reset_email`)
       expect(options).to.equal({
         body: {
           recipient: params.email,
@@ -40,32 +40,32 @@ experiment('notify connectors', () => {
             reset_url: `http://127.0.0.1:8000/reset_password_change_password?resetGuid=${params.resetGuid}`
           }
         }
-      });
-    });
+      })
+    })
 
     test('resolves with the response from the POST request', async () => {
-      const data = await notify.sendPasswordResetEmail(params);
-      expect(data).to.equal(response);
-    });
+      const data = await notify.sendPasswordResetEmail(params)
+      expect(data).to.equal(response)
+    })
 
     experiment('when the POST fails', () => {
       beforeEach(async () => {
-        helpers.serviceRequest.post.rejects();
-      });
+        helpers.serviceRequest.post.rejects()
+      })
 
       test('throws and logs an error', async () => {
-        const func = () => notify.sendPasswordResetEmail(params);
-        await expect(func()).to.reject();
-        expect(logger.error.callCount).to.equal(1);
-      });
-    });
-  });
+        const func = () => notify.sendPasswordResetEmail(params)
+        await expect(func()).to.reject()
+        expect(logger.error.callCount).to.equal(1)
+      })
+    })
+  })
 
   experiment('sendPasswordLockEmail', () => {
     test('calls serviceRequest.post with correct arguments', async () => {
-      await notify.sendPasswordLockEmail(params);
-      const [uri, options] = helpers.serviceRequest.post.lastCall.args;
-      expect(uri).to.equal(`${config.services.water}/notify/password_locked_email`);
+      await notify.sendPasswordLockEmail(params)
+      const [uri, options] = helpers.serviceRequest.post.lastCall.args
+      expect(uri).to.equal(`${config.services.water}/notify/password_locked_email`)
       expect(options).to.equal({
         body: {
           recipient: params.email,
@@ -74,24 +74,24 @@ experiment('notify connectors', () => {
             reset_url: `http://127.0.0.1:8000/reset_password_change_password?resetGuid=${params.resetGuid}`
           }
         }
-      });
-    });
+      })
+    })
 
     test('resolves with the response from the POST request', async () => {
-      const data = await notify.sendPasswordLockEmail(params);
-      expect(data).to.be.true();
-    });
+      const data = await notify.sendPasswordLockEmail(params)
+      expect(data).to.be.true()
+    })
 
     experiment('when the POST fails', () => {
       beforeEach(async () => {
-        helpers.serviceRequest.post.rejects();
-      });
+        helpers.serviceRequest.post.rejects()
+      })
 
       test('throws and logs an error', async () => {
-        const func = () => notify.sendPasswordLockEmail(params);
-        await expect(func()).to.reject();
-        expect(logger.error.callCount).to.equal(3);
-      });
-    });
-  });
-});
+        const func = () => notify.sendPasswordLockEmail(params)
+        await expect(func()).to.reject()
+        expect(logger.error.callCount).to.equal(3)
+      })
+    })
+  })
+})

--- a/test/lib/connectors/water.js
+++ b/test/lib/connectors/water.js
@@ -1,62 +1,62 @@
-const { expect } = require('@hapi/code');
-const { beforeEach, afterEach, experiment, test } = exports.lab = require('@hapi/lab').script();
-const sinon = require('sinon');
-const sandbox = sinon.createSandbox();
-const helpers = require('@envage/water-abstraction-helpers');
+const { expect } = require('@hapi/code')
+const { beforeEach, afterEach, experiment, test } = exports.lab = require('@hapi/lab').script()
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
+const helpers = require('@envage/water-abstraction-helpers')
 
-const config = require('../../../config');
-const water = require('../../../src/lib/connectors/water');
-const { logger } = require('../../../src/logger');
+const config = require('../../../config')
+const water = require('../../../src/lib/connectors/water')
+const { logger } = require('../../../src/logger')
 
-const response = { foo: 'bar' };
-const personalisation = { name: 'bob' };
-const recipient = 'bob@example.com';
-const ref = 'message_1';
-const token = 'token';
+const response = { foo: 'bar' }
+const personalisation = { name: 'bob' }
+const recipient = 'bob@example.com'
+const ref = 'message_1'
+const token = 'token'
 
 experiment('water connectors', () => {
-  let jwtToken;
+  let jwtToken
 
   beforeEach(async () => {
-    sandbox.stub(helpers.serviceRequest, 'post').resolves(response);
-    sandbox.stub(logger, 'error');
-    jwtToken = process.env.JWT_TOKEN;
-    process.env.JWT_TOKEN = token;
-  });
+    sandbox.stub(helpers.serviceRequest, 'post').resolves(response)
+    sandbox.stub(logger, 'error')
+    jwtToken = process.env.JWT_TOKEN
+    process.env.JWT_TOKEN = token
+  })
 
   afterEach(async () => {
-    process.env.JWT_TOKEN = jwtToken;
-    sandbox.restore();
-  });
+    process.env.JWT_TOKEN = jwtToken
+    sandbox.restore()
+  })
 
   experiment('sendNotifyMessage', () => {
     test('calls serviceRequest.post with correct arguments', async () => {
-      await water.sendNotifyMessage(ref, recipient, personalisation);
-      const [uri, options] = helpers.serviceRequest.post.lastCall.args;
-      expect(uri).to.equal(`${config.services.water}/notify/${ref}`);
+      await water.sendNotifyMessage(ref, recipient, personalisation)
+      const [uri, options] = helpers.serviceRequest.post.lastCall.args
+      expect(uri).to.equal(`${config.services.water}/notify/${ref}`)
       expect(options).to.equal({
         body: {
           recipient,
           personalisation
         }
-      });
-    });
+      })
+    })
 
     test('resolves with the response from the POST request', async () => {
-      const data = await water.sendNotifyMessage(ref, recipient, personalisation);
-      expect(data).to.equal(response);
-    });
+      const data = await water.sendNotifyMessage(ref, recipient, personalisation)
+      expect(data).to.equal(response)
+    })
 
     experiment('when the POST fails', () => {
       beforeEach(async () => {
-        helpers.serviceRequest.post.rejects();
-      });
+        helpers.serviceRequest.post.rejects()
+      })
 
       test('throws and logs an error', async () => {
-        const func = () => water.sendNotifyMessage(ref, recipient, personalisation);
-        await expect(func()).to.reject();
-        expect(logger.error.callCount).to.equal(1);
-      });
-    });
-  });
-});
+        const func = () => water.sendNotifyMessage(ref, recipient, personalisation)
+        await expect(func()).to.reject()
+        expect(logger.error.callCount).to.equal(1)
+      })
+    })
+  })
+})

--- a/test/lib/helpers.js
+++ b/test/lib/helpers.js
@@ -1,36 +1,36 @@
-const helpers = require('../../src/lib/helpers');
-const { expect } = require('@hapi/code');
-const { test, experiment } = exports.lab = require('@hapi/lab').script();
+const helpers = require('../../src/lib/helpers')
+const { expect } = require('@hapi/code')
+const { test, experiment } = exports.lab = require('@hapi/lab').script()
 
-const allNumberCodeRegex = /[\d|\w]/;
+const allNumberCodeRegex = /[\d|\w]/
 
-const plainText = 'Test1234';
-const hash = '$2b$10$H8Vd7SlmsEZ..N/.wDIlXOUeMD0oAjnJi8zmKL6Rt3H69ITpMUhOK';
+const plainText = 'Test1234'
+const hash = '$2b$10$H8Vd7SlmsEZ..N/.wDIlXOUeMD0oAjnJi8zmKL6Rt3H69ITpMUhOK'
 
 experiment('helpers', () => {
   experiment('createDigitCode', () => {
     test('creates a random 6 digit code by default', async () => {
-      const result = helpers.createDigitCode();
-      expect(result).to.match(allNumberCodeRegex);
-      expect(result.toString()).to.have.length(6);
-    });
+      const result = helpers.createDigitCode()
+      expect(result).to.match(allNumberCodeRegex)
+      expect(result.toString()).to.have.length(6)
+    })
 
     test('creates a random digit code of any length, given a certain number', async () => {
-      const result = helpers.createDigitCode(4);
-      expect(result).to.match(allNumberCodeRegex);
-      expect(result.toString()).to.have.length(4);
-    });
-  });
+      const result = helpers.createDigitCode(4)
+      expect(result).to.match(allNumberCodeRegex)
+      expect(result.toString()).to.have.length(4)
+    })
+  })
 
   experiment('testPassword', () => {
     test('when password matches hash, resolves true', async () => {
-      const result = await helpers.testPassword(plainText, hash);
-      expect(result).to.equal(true);
-    });
+      const result = await helpers.testPassword(plainText, hash)
+      expect(result).to.equal(true)
+    })
 
     test('when password does not match hash, resolves false', async () => {
-      const result = await helpers.testPassword('wrong', hash);
-      expect(result).to.equal(false);
-    });
-  });
-});
+      const result = await helpers.testPassword('wrong', hash)
+      expect(result).to.equal(false)
+    })
+  })
+})

--- a/test/lib/repos/change-email.js
+++ b/test/lib/repos/change-email.js
@@ -1,75 +1,75 @@
-const Repository = require('@envage/hapi-pg-rest-api/src/repository');
-const repos = require('../../../src/lib/repos');
-const { expect } = require('@hapi/code');
-const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const sinon = require('sinon');
-const sandbox = sinon.createSandbox();
+const Repository = require('@envage/hapi-pg-rest-api/src/repository')
+const repos = require('../../../src/lib/repos')
+const { expect } = require('@hapi/code')
+const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
 
-const sixDigitCodeRegex = /[\d|\w]{6}/;
+const sixDigitCodeRegex = /[\d|\w]{6}/
 
-const changeEmailRepo = repos.changeEmailRepo;
+const changeEmailRepo = repos.changeEmailRepo
 
 const response = {
   rows: [{
     email_change_id: 'email_change_1',
     attempts: 2
   }]
-};
+}
 
 experiment('ChangeEmailRepository', () => {
   beforeEach(async () => {
-    sandbox.stub(Repository.prototype, 'find');
-    sandbox.stub(Repository.prototype, 'dbQuery').resolves(response);
-  });
+    sandbox.stub(Repository.prototype, 'find')
+    sandbox.stub(Repository.prototype, 'dbQuery').resolves(response)
+  })
 
-  afterEach(async () => sandbox.restore());
+  afterEach(async () => sandbox.restore())
 
   experiment('findOneByUserId', () => {
     test('calls this.dbQuery with correct params', async () => {
-      await changeEmailRepo.findOneByUserId(1234);
-      const [query, params] = Repository.prototype.dbQuery.lastCall.args;
-      expect(query).to.be.a.string();
-      expect(params).to.equal([1234]);
-    });
+      await changeEmailRepo.findOneByUserId(1234)
+      const [query, params] = Repository.prototype.dbQuery.lastCall.args
+      expect(query).to.be.a.string()
+      expect(params).to.equal([1234])
+    })
 
     test('resolves with first record found', async () => {
-      const result = await changeEmailRepo.findOneByUserId(1234);
-      expect(result).to.equal(response.rows[0]);
-    });
-  });
+      const result = await changeEmailRepo.findOneByUserId(1234)
+      expect(result).to.equal(response.rows[0])
+    })
+  })
 
   experiment('create', () => {
     test('calls this.dbQuery with correct params', async () => {
-      await changeEmailRepo.create(1234, 'mail@example.com');
-      const [query, params] = Repository.prototype.dbQuery.lastCall.args;
-      expect(query).to.be.a.string();
+      await changeEmailRepo.create(1234, 'mail@example.com')
+      const [query, params] = Repository.prototype.dbQuery.lastCall.args
+      expect(query).to.be.a.string()
 
-      expect(params[0]).to.equal(1234);
-      expect(params[1]).to.equal('mail@example.com');
-      expect(params[2]).to.match(sixDigitCodeRegex);
-    });
+      expect(params[0]).to.equal(1234)
+      expect(params[1]).to.equal('mail@example.com')
+      expect(params[2]).to.match(sixDigitCodeRegex)
+    })
 
     test('resolves with first record found', async () => {
-      const result = await changeEmailRepo.create(1234, 'mail@example.com');
-      expect(result).to.equal(response.rows[0]);
-    });
-  });
+      const result = await changeEmailRepo.create(1234, 'mail@example.com')
+      expect(result).to.equal(response.rows[0])
+    })
+  })
 
   experiment('incrementSecurityCodeAttempts', () => {
     test('calls this.dbQuery with correct params', async () => {
-      await changeEmailRepo.incrementSecurityCodeAttempts(1234);
-      const [query, params] = Repository.prototype.dbQuery.lastCall.args;
-      expect(query).to.be.a.string();
-      expect(params).to.equal([1234]);
-    });
-  });
+      await changeEmailRepo.incrementSecurityCodeAttempts(1234)
+      const [query, params] = Repository.prototype.dbQuery.lastCall.args
+      expect(query).to.be.a.string()
+      expect(params).to.equal([1234])
+    })
+  })
 
   experiment('updateVerified', () => {
     test('calls this.dbQuery with correct params', async () => {
-      await changeEmailRepo.updateVerified(1234, '012345');
-      const [query, params] = Repository.prototype.dbQuery.lastCall.args;
-      expect(query).to.be.a.string();
-      expect(params).to.equal([1234, '012345']);
-    });
-  });
-});
+      await changeEmailRepo.updateVerified(1234, '012345')
+      const [query, params] = Repository.prototype.dbQuery.lastCall.args
+      expect(query).to.be.a.string()
+      expect(params).to.equal([1234, '012345'])
+    })
+  })
+})

--- a/test/lib/repos/reauthentication.js
+++ b/test/lib/repos/reauthentication.js
@@ -1,50 +1,50 @@
-const { expect } = require('@hapi/code');
-const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const sinon = require('sinon');
-const sandbox = sinon.createSandbox();
+const { expect } = require('@hapi/code')
+const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
 
-const ReauthenticationRepository = require('../../../src/lib/repos/reauthentication');
+const ReauthenticationRepository = require('../../../src/lib/repos/reauthentication')
 
-const userId = 123;
+const userId = 123
 const response = {
   rows: [{
     user_id: userId
   }]
-};
+}
 
 experiment('ReauthenticationRepository', () => {
-  let connection, repo;
+  let connection, repo
 
   beforeEach(async () => {
     connection = {
       query: sandbox.stub().resolves(response)
-    };
+    }
     repo = new ReauthenticationRepository({
       connection
-    });
-  });
-  afterEach(async () => sandbox.restore());
+    })
+  })
+  afterEach(async () => sandbox.restore())
 
   experiment('findByUserId', () => {
     test('makes a DB query with the correct arguments', async () => {
-      await repo.findByUserId(userId);
-      const [query, params] = connection.query.lastCall.args;
-      expect(query).to.be.a.string();
-      expect(params).to.equal([userId]);
-    });
+      await repo.findByUserId(userId)
+      const [query, params] = connection.query.lastCall.args
+      expect(query).to.be.a.string()
+      expect(params).to.equal([userId])
+    })
 
     test('resolves with the first row of data', async () => {
-      const data = await repo.findByUserId(userId);
-      expect(data).to.equal(response.rows[0]);
-    });
-  });
+      const data = await repo.findByUserId(userId)
+      expect(data).to.equal(response.rows[0])
+    })
+  })
 
   experiment('resetAttemptCounter', () => {
     test('makes a DB query with the correct arguments', async () => {
-      await repo.resetAttemptCounter(userId);
-      const [query, params] = connection.query.lastCall.args;
-      expect(query).to.be.a.string();
-      expect(params).to.equal([userId]);
-    });
-  });
-});
+      await repo.resetAttemptCounter(userId)
+      const [query, params] = connection.query.lastCall.args
+      expect(query).to.be.a.string()
+      expect(params).to.equal([userId])
+    })
+  })
+})

--- a/test/lib/repos/users.js
+++ b/test/lib/repos/users.js
@@ -1,79 +1,79 @@
-const moment = require('moment');
-const UsersRepository = require('../../../src/lib/repos/users');
-const Repository = require('@envage/hapi-pg-rest-api/src/repository');
-const { pool } = require('../../../src/lib/connectors/db');
-const { expect } = require('@hapi/code');
-const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const sinon = require('sinon');
-const sandbox = sinon.createSandbox();
+const moment = require('moment')
+const UsersRepository = require('../../../src/lib/repos/users')
+const Repository = require('@envage/hapi-pg-rest-api/src/repository')
+const { pool } = require('../../../src/lib/connectors/db')
+const { expect } = require('@hapi/code')
+const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
 
-const now = moment();
+const now = moment()
 
 const usersRepo = new UsersRepository({
   connection: pool,
   table: 'idm.users',
   primaryKey: 'user_id'
-});
+})
 
 experiment('UsersRepository', () => {
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('findById', () => {
     beforeEach(async () => {
-      sandbox.stub(Repository.prototype, 'find').returns({ rows: [{ first: 'element' }] });
-    });
+      sandbox.stub(Repository.prototype, 'find').returns({ rows: [{ first: 'element' }] })
+    })
 
-    afterEach(async () => sandbox.restore());
+    afterEach(async () => sandbox.restore())
 
     test('returns first element in data', async () => {
-      const result = await usersRepo.findById(1234);
-      expect(result).to.equal({ first: 'element' });
-    });
+      const result = await usersRepo.findById(1234)
+      expect(result).to.equal({ first: 'element' })
+    })
 
     test('calls this.find with correct params', async () => {
-      await usersRepo.findById(1234);
-      const [params] = Repository.prototype.find.lastCall.args;
-      expect(params).to.equal({ user_id: 1234 });
-    });
-  });
+      await usersRepo.findById(1234)
+      const [params] = Repository.prototype.find.lastCall.args
+      expect(params).to.equal({ user_id: 1234 })
+    })
+  })
 
   experiment('findGroups', () => {
     beforeEach(async () => {
-      sandbox.stub(Repository.prototype, 'dbQuery').resolves({ rows: [{ group: 'group_1' }] });
-    });
+      sandbox.stub(Repository.prototype, 'dbQuery').resolves({ rows: [{ group: 'group_1' }] })
+    })
 
     test('calls dbQuery with correct params', async () => {
-      await usersRepo.findGroups(1234);
-      const [query, params] = Repository.prototype.dbQuery.lastCall.args;
-      expect(query).to.be.a.string();
-      expect(params).to.equal([1234]);
-    });
+      await usersRepo.findGroups(1234)
+      const [query, params] = Repository.prototype.dbQuery.lastCall.args
+      expect(query).to.be.a.string()
+      expect(params).to.equal([1234])
+    })
 
     test('maps returned rows to an an array of strings', async () => {
-      const result = await usersRepo.findGroups(1234);
-      expect(result).to.equal(['group_1']);
-    });
-  });
+      const result = await usersRepo.findGroups(1234)
+      expect(result).to.equal(['group_1'])
+    })
+  })
 
   experiment('findRoles', () => {
     beforeEach(async () => {
-      sandbox.stub(Repository.prototype, 'dbQuery').resolves({ rows: [{ role: 'role_1' }] });
-    });
+      sandbox.stub(Repository.prototype, 'dbQuery').resolves({ rows: [{ role: 'role_1' }] })
+    })
 
     test('calls dbQuery with correct params', async () => {
-      await usersRepo.findRoles(1234);
-      const [query, params] = Repository.prototype.dbQuery.lastCall.args;
-      expect(query).to.be.a.string();
-      expect(params).to.equal([1234]);
-    });
+      await usersRepo.findRoles(1234)
+      const [query, params] = Repository.prototype.dbQuery.lastCall.args
+      expect(query).to.be.a.string()
+      expect(params).to.equal([1234])
+    })
 
     test('maps returned rows to an an array of strings', async () => {
-      const result = await usersRepo.findRoles(1234);
-      expect(result).to.equal(['role_1']);
-    });
-  });
+      const result = await usersRepo.findRoles(1234)
+      expect(result).to.equal(['role_1'])
+    })
+  })
 
   experiment('findInSameApplication', () => {
     beforeEach(async () => {
@@ -81,23 +81,23 @@ experiment('UsersRepository', () => {
         rows: [{
           user_id: 1
         }]
-      });
-    });
+      })
+    })
 
-    afterEach(async () => sandbox.restore());
+    afterEach(async () => sandbox.restore())
 
     test('calls this.dbQuery with correct params', async () => {
-      await usersRepo.findInSameApplication(1234, 'test@domain.com');
-      const [, params] = Repository.prototype.dbQuery.lastCall.args;
-      expect(params[0]).to.equal(1234);
-      expect(params[1]).to.equal('test@domain.com');
-    });
+      await usersRepo.findInSameApplication(1234, 'test@domain.com')
+      const [, params] = Repository.prototype.dbQuery.lastCall.args
+      expect(params[0]).to.equal(1234)
+      expect(params[1]).to.equal('test@domain.com')
+    })
 
     test('resolves with the first user record found', async () => {
-      const result = await usersRepo.findInSameApplication(1234, 'test@domain.com');
-      expect(result).to.be.an.object();
-    });
-  });
+      const result = await usersRepo.findInSameApplication(1234, 'test@domain.com')
+      expect(result).to.be.an.object()
+    })
+  })
 
   experiment('updateEmailAddress', () => {
     beforeEach(async () => {
@@ -105,132 +105,132 @@ experiment('UsersRepository', () => {
         rows: [{
           user_id: 'user_1'
         }]
-      });
-    });
+      })
+    })
 
-    afterEach(async () => sandbox.restore());
+    afterEach(async () => sandbox.restore())
 
     test('calls this.update with correct params', async () => {
-      await usersRepo.updateEmailAddress(1234, 'test@domain.com', now);
-      const [filter, data] = Repository.prototype.update.lastCall.args;
-      expect(filter).to.equal({ user_id: 1234 });
-      expect(data.user_name).to.equal('test@domain.com');
-      expect(data.date_updated).to.equal(now.format());
-    });
+      await usersRepo.updateEmailAddress(1234, 'test@domain.com', now)
+      const [filter, data] = Repository.prototype.update.lastCall.args
+      expect(filter).to.equal({ user_id: 1234 })
+      expect(data.user_name).to.equal('test@domain.com')
+      expect(data.date_updated).to.equal(now.format())
+    })
 
     test('resolves with first updated record', async () => {
-      const user = await usersRepo.updateEmailAddress(1234, 'test@domain.com');
-      expect(user.user_id).to.equal('user_1');
-    });
-  });
+      const user = await usersRepo.updateEmailAddress(1234, 'test@domain.com')
+      expect(user.user_id).to.equal('user_1')
+    })
+  })
 
   experiment('findByUsername', () => {
-    let result;
+    let result
 
     beforeEach(async () => {
       sandbox.stub(Repository.prototype, 'dbQuery')
-        .resolves({ rows: [{ user_id: 123 }] });
-      result = await usersRepo.findByUsername('mail@example.com', 'water_vml');
-    });
+        .resolves({ rows: [{ user_id: 123 }] })
+      result = await usersRepo.findByUsername('mail@example.com', 'water_vml')
+    })
 
     test('calls this.dbQuery with correct params', async () => {
-      const [query, params] = Repository.prototype.dbQuery.lastCall.args;
-      expect(query).to.be.a.string();
-      expect(params).to.equal(['mail@example.com', 'water_vml']);
-    });
+      const [query, params] = Repository.prototype.dbQuery.lastCall.args
+      expect(query).to.be.a.string()
+      expect(params).to.equal(['mail@example.com', 'water_vml'])
+    })
 
     test('resolves with the first row found', async () => {
-      expect(result).to.equal({ user_id: 123 });
-    });
-  });
+      expect(result).to.equal({ user_id: 123 })
+    })
+  })
 
   experiment('incrementLockCount', () => {
-    let result;
+    let result
 
     beforeEach(async () => {
       sandbox.stub(Repository.prototype, 'dbQuery')
-        .resolves({ rows: [{ user_id: 123 }] });
-      result = await usersRepo.incrementLockCount(123);
-    });
+        .resolves({ rows: [{ user_id: 123 }] })
+      result = await usersRepo.incrementLockCount(123)
+    })
 
     test('calls this.dbQuery with correct params', async () => {
-      const [query, params] = Repository.prototype.dbQuery.lastCall.args;
-      expect(query).to.be.a.string();
-      expect(params).to.equal([123]);
-    });
+      const [query, params] = Repository.prototype.dbQuery.lastCall.args
+      expect(query).to.be.a.string()
+      expect(params).to.equal([123])
+    })
 
     test('resolves with the first row found', async () => {
-      expect(result).to.equal({ user_id: 123 });
-    });
-  });
+      expect(result).to.equal({ user_id: 123 })
+    })
+  })
 
   experiment('voidCurrentPassword', () => {
     beforeEach(async () => {
-      sandbox.stub(Repository.prototype, 'dbQuery');
-      await usersRepo.voidCurrentPassword(123, 'reset-guid');
-    });
+      sandbox.stub(Repository.prototype, 'dbQuery')
+      await usersRepo.voidCurrentPassword(123, 'reset-guid')
+    })
 
     test('calls this.dbQuery with correct params', async () => {
-      const [query, params] = Repository.prototype.dbQuery.lastCall.args;
-      expect(query).to.be.a.string();
-      expect(params).to.equal([123, 'reset-guid']);
-    });
-  });
+      const [query, params] = Repository.prototype.dbQuery.lastCall.args
+      expect(query).to.be.a.string()
+      expect(params).to.equal([123, 'reset-guid'])
+    })
+  })
 
   experiment('updateResetGuid', () => {
     beforeEach(async () => {
-      sandbox.stub(Repository.prototype, 'update');
-      await usersRepo.updateResetGuid(123, 'reset-guid');
-    });
+      sandbox.stub(Repository.prototype, 'update')
+      await usersRepo.updateResetGuid(123, 'reset-guid')
+    })
 
     test('calls this.update with correct params', async () => {
-      const [filter, data] = Repository.prototype.update.lastCall.args;
-      expect(filter).to.equal({ user_id: 123 });
-      expect(data).to.equal({ reset_guid: 'reset-guid' });
-    });
-  });
+      const [filter, data] = Repository.prototype.update.lastCall.args
+      expect(filter).to.equal({ user_id: 123 })
+      expect(data).to.equal({ reset_guid: 'reset-guid' })
+    })
+  })
 
   experiment('updateAuthenticatedUser', () => {
-    let result;
+    let result
 
     beforeEach(async () => {
       sandbox.stub(Repository.prototype, 'dbQuery')
-        .resolves({ rows: [{ user_id: 123 }] });
-      result = await usersRepo.updateAuthenticatedUser(123);
-    });
+        .resolves({ rows: [{ user_id: 123 }] })
+      result = await usersRepo.updateAuthenticatedUser(123)
+    })
 
     test('calls this.dbQuery with correct params', async () => {
-      const [query, params] = Repository.prototype.dbQuery.lastCall.args;
-      expect(query).to.be.a.string();
-      expect(params).to.equal([123]);
-    });
+      const [query, params] = Repository.prototype.dbQuery.lastCall.args
+      expect(query).to.be.a.string()
+      expect(params).to.equal([123])
+    })
 
     test('resolves with the first row found', async () => {
-      expect(result).to.equal({ user_id: 123 });
-    });
-  });
+      expect(result).to.equal({ user_id: 123 })
+    })
+  })
 
   experiment('findRegistrationsByMonth', () => {
-    let result;
+    let result
     const data = [
       { application: 'water_vml', registrations: 1, month: 2 },
       { application: 'water_vml', registrations: 1, month: 2 }
-    ];
+    ]
 
     beforeEach(async () => {
       sandbox.stub(Repository.prototype, 'dbQuery')
-        .resolves({ rows: data });
-      result = await usersRepo.findRegistrationsByMonth();
-    });
+        .resolves({ rows: data })
+      result = await usersRepo.findRegistrationsByMonth()
+    })
 
     test('calls this.dbQuery with no params', async () => {
-      const [query, params] = Repository.prototype.dbQuery.lastCall.args;
-      expect(query).to.be.a.string();
-      expect(params).to.equal(undefined);
-    });
+      const [query, params] = Repository.prototype.dbQuery.lastCall.args
+      expect(query).to.be.a.string()
+      expect(params).to.equal(undefined)
+    })
 
     test('resolves with an array of objects', async () => {
-      expect(result).to.equal(data);
-    });
-  });
-});
+      expect(result).to.equal(data)
+    })
+  })
+})

--- a/test/modules/authenticate/controller.js
+++ b/test/modules/authenticate/controller.js
@@ -1,17 +1,17 @@
-const controller = require('../../../src/modules/authenticate/controller');
-const repos = require('../../../src/lib/repos');
-const helpers = require('../../../src/lib/helpers');
-const { logger } = require('../../../src/logger');
-const Notify = require('../../../src/lib/connectors/notify');
+const controller = require('../../../src/modules/authenticate/controller')
+const repos = require('../../../src/lib/repos')
+const helpers = require('../../../src/lib/helpers')
+const { logger } = require('../../../src/logger')
+const Notify = require('../../../src/lib/connectors/notify')
 
-const { expect } = require('@hapi/code');
-const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const sinon = require('sinon');
-const sandbox = sinon.createSandbox();
+const { expect } = require('@hapi/code')
+const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
 
-const userId = 123;
+const userId = 123
 
-const email = 'mail@example.com';
+const email = 'mail@example.com'
 
 const createRequest = () => ({
   payload: {
@@ -19,64 +19,64 @@ const createRequest = () => ({
     application: 'water_vml',
     password: 'test-password'
   }
-});
+})
 
 experiment('authentication controller', () => {
-  let h, code, request;
+  let h, code, request
 
   beforeEach(async () => {
-    code = sandbox.stub();
+    code = sandbox.stub()
     h = {
       response: sandbox.stub().returns({ code })
-    };
-    request = createRequest();
+    }
+    request = createRequest()
 
-    sandbox.stub(repos.usersRepo, 'findByUsername');
+    sandbox.stub(repos.usersRepo, 'findByUsername')
     sandbox.stub(repos.usersRepo, 'incrementLockCount').resolves({
       bad_logins: 5
-    });
-    sandbox.stub(repos.usersRepo, 'voidCurrentPassword');
+    })
+    sandbox.stub(repos.usersRepo, 'voidCurrentPassword')
     sandbox.stub(repos.usersRepo, 'updateAuthenticatedUser').resolves({
       user_id: userId,
       password: 'top-secret'
-    });
+    })
 
-    sandbox.stub(Notify, 'sendPasswordLockEmail');
+    sandbox.stub(Notify, 'sendPasswordLockEmail')
 
-    sandbox.stub(logger, 'info');
-    sandbox.stub(logger, 'error');
-    sandbox.stub(helpers, 'testPassword').resolves(false);
-  });
+    sandbox.stub(logger, 'info')
+    sandbox.stub(logger, 'error')
+    sandbox.stub(helpers, 'testPassword').resolves(false)
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   const expectUnauthorized = () => {
-    const response = h.response.lastCall.args[0];
-    expect(response.user_id).to.equal(null);
-    expect(response.err).to.equal('Unknown user name or password');
-    expect(code.calledWith(401)).to.equal(true);
-  };
+    const response = h.response.lastCall.args[0]
+    expect(response.user_id).to.equal(null)
+    expect(response.err).to.equal('Unknown user name or password')
+    expect(code.calledWith(401)).to.equal(true)
+  }
 
   experiment('postAuthenticate', () => {
     test('throws a 401 error if user not found', async () => {
-      repos.usersRepo.findByUsername.resolves();
-      await controller.postAuthenticate(request, h);
-      expectUnauthorized();
+      repos.usersRepo.findByUsername.resolves()
+      await controller.postAuthenticate(request, h)
+      expectUnauthorized()
       expect(logger.info.calledWith(`User ${email} not found`))
-        .to.equal(true);
-    });
+        .to.equal(true)
+    })
 
     test('throws a 401 error if user account locked', async () => {
       repos.usersRepo.findByUsername.resolves({
         enabled: false
-      });
-      await controller.postAuthenticate(request, h);
-      expectUnauthorized();
+      })
+      await controller.postAuthenticate(request, h)
+      expectUnauthorized()
       expect(logger.info.calledWith(`User account ${email} is disabled`))
-        .to.equal(true);
-    });
+        .to.equal(true)
+    })
 
     experiment('when the password is wrong and < 10 attempts', () => {
       beforeEach(async () => {
@@ -84,28 +84,28 @@ experiment('authentication controller', () => {
           user_id: userId,
           enabled: true,
           password: 'x'
-        });
-        await controller.postAuthenticate(request, h);
-      });
+        })
+        await controller.postAuthenticate(request, h)
+      })
 
       test('throws a 401 error', async () => {
-        expectUnauthorized();
+        expectUnauthorized()
         expect(logger.info.calledWith(`User ${email} unauthorized`))
-          .to.equal(true);
-      });
+          .to.equal(true)
+      })
 
       test('increments the lock count', async () => {
-        expect(repos.usersRepo.incrementLockCount.calledWith(userId)).to.be.true();
-      });
+        expect(repos.usersRepo.incrementLockCount.calledWith(userId)).to.be.true()
+      })
 
       test('does not void the password', async () => {
-        expect(repos.usersRepo.voidCurrentPassword.called).to.be.false();
-      });
+        expect(repos.usersRepo.voidCurrentPassword.called).to.be.false()
+      })
 
       test('does not send an email', async () => {
-        expect(Notify.sendPasswordLockEmail.called).to.be.false();
-      });
-    });
+        expect(Notify.sendPasswordLockEmail.called).to.be.false()
+      })
+    })
 
     experiment('when the password is wrong and exactly 10 attempts', () => {
       beforeEach(async () => {
@@ -115,40 +115,40 @@ experiment('authentication controller', () => {
           application: 'water_vml',
           enabled: true,
           password: 'x'
-        });
+        })
         repos.usersRepo.incrementLockCount.resolves({
           bad_logins: 10
-        });
-        await controller.postAuthenticate(request, h);
-      });
+        })
+        await controller.postAuthenticate(request, h)
+      })
 
       test('throws a 401 error', async () => {
-        expectUnauthorized();
+        expectUnauthorized()
         expect(logger.info.calledWith(`User ${email} unauthorized`))
-          .to.equal(true);
-      });
+          .to.equal(true)
+      })
 
       test('increments the lock count', async () => {
-        expect(repos.usersRepo.incrementLockCount.calledWith(userId)).to.be.true();
-      });
+        expect(repos.usersRepo.incrementLockCount.calledWith(userId)).to.be.true()
+      })
 
       test('voids the password', async () => {
-        const { args } = repos.usersRepo.voidCurrentPassword.lastCall;
-        expect(args[0]).to.equal(userId);
-        expect(args[1]).to.be.a.string().length(36);
-      });
+        const { args } = repos.usersRepo.voidCurrentPassword.lastCall
+        expect(args[0]).to.equal(userId)
+        expect(args[1]).to.be.a.string().length(36)
+      })
 
       test('sends a password lock email', async () => {
-        const [options] = Notify.sendPasswordLockEmail.lastCall.args;
-        expect(options.email).to.equal('test@example.com');
-        expect(options.firstname).to.equal('User');
-        expect(options.resetGuid).to.be.a.string().length(36);
-        expect(options.userApplication).to.equal('water_vml');
-      });
-    });
+        const [options] = Notify.sendPasswordLockEmail.lastCall.args
+        expect(options.email).to.equal('test@example.com')
+        expect(options.firstname).to.equal('User')
+        expect(options.resetGuid).to.be.a.string().length(36)
+        expect(options.userApplication).to.equal('water_vml')
+      })
+    })
 
     experiment('when the password is correct', () => {
-      let response;
+      let response
 
       beforeEach(async () => {
         repos.usersRepo.findByUsername.resolves({
@@ -156,33 +156,33 @@ experiment('authentication controller', () => {
           user_name: 'test@example.com',
           application: 'water_vml',
           enabled: true
-        });
+        })
 
-        helpers.testPassword.resolves(true);
+        helpers.testPassword.resolves(true)
 
-        response = await controller.postAuthenticate(request, h);
-      });
+        response = await controller.postAuthenticate(request, h)
+      })
 
       test('updates the authenticated user last login time', async () => {
-        expect(repos.usersRepo.updateAuthenticatedUser.calledWith(userId)).to.equal(true);
-      });
+        expect(repos.usersRepo.updateAuthenticatedUser.calledWith(userId)).to.equal(true)
+      })
 
       test('responds with user details excluding password', async () => {
-        expect(response.user_id).to.equal(userId);
-        expect(response.password).to.be.undefined();
-        expect(response.err).to.equal(null);
-      });
-    });
+        expect(response.user_id).to.equal(userId)
+        expect(response.password).to.be.undefined()
+        expect(response.err).to.equal(null)
+      })
+    })
 
     experiment('non-Boom errors are rethrown', () => {
       beforeEach(async () => {
-        repos.usersRepo.findByUsername.rejects();
-      });
+        repos.usersRepo.findByUsername.rejects()
+      })
 
       test('throws an error', async () => {
-        const func = () => controller.postAuthenticate(request, h);
-        expect(func()).to.reject();
-      });
-    });
-  });
-});
+        const func = () => controller.postAuthenticate(request, h)
+        expect(func()).to.reject()
+      })
+    })
+  })
+})

--- a/test/modules/change-email/controller.js
+++ b/test/modules/change-email/controller.js
@@ -1,13 +1,13 @@
-const controller = require('../../../src/modules/change-email/controller');
-const repos = require('../../../src/lib/repos');
-const { expect } = require('@hapi/code');
-const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const sinon = require('sinon');
-const sandbox = sinon.createSandbox();
+const controller = require('../../../src/modules/change-email/controller')
+const repos = require('../../../src/lib/repos')
+const { expect } = require('@hapi/code')
+const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
 
-const userId = 123;
-const securityCode = '987123';
-const newEmail = 'new@example.com';
+const userId = 123
+const securityCode = '987123'
+const newEmail = 'new@example.com'
 
 const createResponse = (overrides = {}) => ({
   user_id: userId,
@@ -17,79 +17,79 @@ const createResponse = (overrides = {}) => ({
   date_verified: null,
   security_code: securityCode,
   ...overrides
-});
+})
 
 experiment('change email controller', () => {
-  let h, code;
+  let h, code
 
   const expectErrorResponse = errorCode => {
-    const response = h.response.lastCall.args[0];
-    expect(response.data).to.equal(null);
-    expect(response.error).to.be.a.string();
-    expect(code.calledWith(errorCode)).to.equal(true);
-  };
+    const response = h.response.lastCall.args[0]
+    expect(response.data).to.equal(null)
+    expect(response.error).to.be.a.string()
+    expect(code.calledWith(errorCode)).to.equal(true)
+  }
 
   beforeEach(async () => {
-    sandbox.stub(repos.changeEmailRepo, 'findOneByUserId');
-    sandbox.stub(repos.changeEmailRepo, 'create');
-    sandbox.stub(repos.changeEmailRepo, 'incrementSecurityCodeAttempts');
-    sandbox.stub(repos.changeEmailRepo, 'updateVerified');
+    sandbox.stub(repos.changeEmailRepo, 'findOneByUserId')
+    sandbox.stub(repos.changeEmailRepo, 'create')
+    sandbox.stub(repos.changeEmailRepo, 'incrementSecurityCodeAttempts')
+    sandbox.stub(repos.changeEmailRepo, 'updateVerified')
 
-    sandbox.stub(repos.usersRepo, 'findInSameApplication');
-    sandbox.stub(repos.usersRepo, 'updateEmailAddress');
-    code = sandbox.stub();
+    sandbox.stub(repos.usersRepo, 'findInSameApplication')
+    sandbox.stub(repos.usersRepo, 'updateEmailAddress')
+    code = sandbox.stub()
     h = {
       response: sandbox.stub().returns({ code })
-    };
-  });
+    }
+  })
 
-  afterEach(async () => sandbox.restore());
+  afterEach(async () => sandbox.restore())
 
   experiment('getStatus', () => {
     const request = {
       params: {
         userId
       }
-    };
+    }
 
     test('404 error if email change record not found', async () => {
-      await controller.getStatus(request, h);
-      expectErrorResponse(404);
-    });
+      await controller.getStatus(request, h)
+      expectErrorResponse(404)
+    })
 
     test('returns response if found', async () => {
-      repos.changeEmailRepo.findOneByUserId.resolves(createResponse());
-      const result = await controller.getStatus(request, h);
-      expect(result.error).to.equal(null);
-      expect(result.data.userId).to.equal(userId);
-      expect(result.data.email).to.equal(newEmail);
-      expect(result.data.isLocked).to.equal(false);
-    });
+      repos.changeEmailRepo.findOneByUserId.resolves(createResponse())
+      const result = await controller.getStatus(request, h)
+      expect(result.error).to.equal(null)
+      expect(result.data.userId).to.equal(userId)
+      expect(result.data.email).to.equal(newEmail)
+      expect(result.data.isLocked).to.equal(false)
+    })
 
     test('locked flag in response is true if date_verified not null', async () => {
       repos.changeEmailRepo.findOneByUserId.resolves(createResponse({
         date_verified: '2019-08-08 12:00:00'
-      }));
-      const result = await controller.getStatus(request, h);
-      expect(result.data.isLocked).to.equal(true);
-    });
+      }))
+      const result = await controller.getStatus(request, h)
+      expect(result.data.isLocked).to.equal(true)
+    })
 
     test('locked flag in response is true if >=3 email change attempts', async () => {
       repos.changeEmailRepo.findOneByUserId.resolves(createResponse({
         attempts: 3
-      }));
-      const result = await controller.getStatus(request, h);
-      expect(result.data.isLocked).to.equal(true);
-    });
+      }))
+      const result = await controller.getStatus(request, h)
+      expect(result.data.isLocked).to.equal(true)
+    })
 
     test('locked flag in response is true if >=3 security code attempts', async () => {
       repos.changeEmailRepo.findOneByUserId.resolves(createResponse({
         security_code_attempts: 4
-      }));
-      const result = await controller.getStatus(request, h);
-      expect(result.data.isLocked).to.equal(true);
-    });
-  });
+      }))
+      const result = await controller.getStatus(request, h)
+      expect(result.data.isLocked).to.equal(true)
+    })
+  })
   experiment('postStartEmailChange', () => {
     const request = {
       params: {
@@ -98,50 +98,50 @@ experiment('change email controller', () => {
       payload: {
         email: newEmail
       }
-    };
+    }
 
     test('429 error if rate limit exceeded', async () => {
       repos.changeEmailRepo.findOneByUserId.resolves(createResponse({
         attempts: 4
-      }));
-      await controller.postStartEmailChange(request, h);
-      expectErrorResponse(429);
-    });
+      }))
+      await controller.postStartEmailChange(request, h)
+      expectErrorResponse(429)
+    })
 
     test('423 error (locked) if already verified', async () => {
       repos.changeEmailRepo.findOneByUserId.resolves(createResponse({
         date_verified: '2019-08-08 12:00:00'
-      }));
-      await controller.postStartEmailChange(request, h);
-      expectErrorResponse(423);
-    });
+      }))
+      await controller.postStartEmailChange(request, h)
+      expectErrorResponse(423)
+    })
 
     test('409 conflict if user already exists', async () => {
-      repos.changeEmailRepo.findOneByUserId.resolves(createResponse());
-      repos.usersRepo.findInSameApplication.resolves({ user_id: 123 });
-      await controller.postStartEmailChange(request, h);
+      repos.changeEmailRepo.findOneByUserId.resolves(createResponse())
+      repos.usersRepo.findInSameApplication.resolves({ user_id: 123 })
+      await controller.postStartEmailChange(request, h)
       expect(repos.usersRepo.findInSameApplication.calledWith(
         userId, newEmail
-      )).to.equal(true);
-      expectErrorResponse(409);
-    });
+      )).to.equal(true)
+      expectErrorResponse(409)
+    })
 
     test('happy path - if not locked or rate limited, upserts', async () => {
-      repos.changeEmailRepo.findOneByUserId.resolves(createResponse());
-      repos.changeEmailRepo.create.resolves(createResponse());
-      const response = await controller.postStartEmailChange(request, h);
+      repos.changeEmailRepo.findOneByUserId.resolves(createResponse())
+      repos.changeEmailRepo.create.resolves(createResponse())
+      const response = await controller.postStartEmailChange(request, h)
       expect(repos.changeEmailRepo.create.calledWith(
         userId, newEmail
-      )).to.equal(true);
+      )).to.equal(true)
       expect(response).to.equal({
         error: null,
         data: {
           userId,
           securityCode
         }
-      });
-    });
-  });
+      })
+    })
+  })
 
   experiment('postSecurityCode', () => {
     const request = {
@@ -151,75 +151,75 @@ experiment('change email controller', () => {
       payload: {
         securityCode
       }
-    };
+    }
 
     test('increments security code attempt counter', async () => {
-      await controller.postSecurityCode(request, h);
+      await controller.postSecurityCode(request, h)
       expect(repos.changeEmailRepo.incrementSecurityCodeAttempts.calledWith(
         userId
-      )).to.equal(true);
-    });
+      )).to.equal(true)
+    })
 
     test('loads email change record for current user and date', async () => {
-      await controller.postSecurityCode(request, h);
+      await controller.postSecurityCode(request, h)
       expect(repos.changeEmailRepo.findOneByUserId.calledWith(
         userId
-      )).to.equal(true);
-    });
+      )).to.equal(true)
+    })
 
     test('404 not found error if email change record not found', async () => {
-      repos.changeEmailRepo.findOneByUserId.resolves();
-      await controller.postSecurityCode(request, h);
-      expectErrorResponse(404);
-    });
+      repos.changeEmailRepo.findOneByUserId.resolves()
+      await controller.postSecurityCode(request, h)
+      expectErrorResponse(404)
+    })
 
     test('429 rate limit exceeded if too many attempts', async () => {
       repos.changeEmailRepo.findOneByUserId.resolves(createResponse({
         security_code_attempts: 4
-      }));
-      await controller.postSecurityCode(request, h);
-      expectErrorResponse(429);
-    });
+      }))
+      await controller.postSecurityCode(request, h)
+      expectErrorResponse(429)
+    })
 
     test('401 unauthorized if security code is not correct', async () => {
       repos.changeEmailRepo.findOneByUserId.resolves(createResponse({
         security_code: '012345'
-      }));
-      await controller.postSecurityCode(request, h);
-      expectErrorResponse(401);
-    });
+      }))
+      await controller.postSecurityCode(request, h)
+      expectErrorResponse(401)
+    })
 
     test('423 locked already verified', async () => {
       repos.changeEmailRepo.findOneByUserId.resolves(createResponse({
         date_verified: '2019-08-08 12:12:00'
-      }));
-      await controller.postSecurityCode(request, h);
-      expectErrorResponse(423);
-    });
+      }))
+      await controller.postSecurityCode(request, h)
+      expectErrorResponse(423)
+    })
 
     experiment('happy path', () => {
-      let result;
+      let result
 
       beforeEach(async () => {
-        repos.changeEmailRepo.findOneByUserId.resolves(createResponse());
+        repos.changeEmailRepo.findOneByUserId.resolves(createResponse())
         repos.usersRepo.updateEmailAddress.resolves({
           user_id: 123,
           user_name: newEmail
-        });
-        result = await controller.postSecurityCode(request, h);
-      });
+        })
+        result = await controller.postSecurityCode(request, h)
+      })
 
       test('updates verified date of email change record', async () => {
         expect(repos.changeEmailRepo.updateVerified.calledWith(
           userId, securityCode
-        )).to.equal(true);
-      });
+        )).to.equal(true)
+      })
 
       test('updates the users email address', async () => {
         expect(repos.usersRepo.updateEmailAddress.calledWith(
           userId, newEmail
-        )).to.equal(true);
-      });
+        )).to.equal(true)
+      })
 
       test('responds with the user ID and new email address', async () => {
         expect(result).to.equal({
@@ -228,8 +228,8 @@ experiment('change email controller', () => {
             userId,
             email: newEmail
           }
-        });
-      });
-    });
-  });
-});
+        })
+      })
+    })
+  })
+})

--- a/test/modules/kpi-reporting/controller.js
+++ b/test/modules/kpi-reporting/controller.js
@@ -1,39 +1,39 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test,
   beforeEach,
   afterEach
-} = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const sandbox = require('sinon').createSandbox();
+} = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const sandbox = require('sinon').createSandbox()
 
-const repos = require('../../../src/lib/repos');
-const controller = require('../../../src/modules/kpi-reporting/controller');
+const repos = require('../../../src/lib/repos')
+const controller = require('../../../src/modules/kpi-reporting/controller')
 
 experiment('/modules/kpi-reporting/controller', () => {
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('getRegistrations', () => {
     experiment('when no data is returned', () => {
       const request = {
-      };
-      const code = sandbox.stub();
+      }
+      const code = sandbox.stub()
       const h = {
         response: sandbox.stub().returns({ code })
-      };
+      }
       beforeEach(async () => {
-        sandbox.stub(repos.usersRepo, 'findRegistrationsByMonth').resolves();
-      });
+        sandbox.stub(repos.usersRepo, 'findRegistrationsByMonth').resolves()
+      })
       test('returns an error when no data found', async () => {
-        const response = await controller.getRegistrations(request, h);
-        expect(response.output.payload.message).to.equal('No data found from users table');
-        expect(response.output.statusCode).to.equal(404);
-      });
-    });
+        const response = await controller.getRegistrations(request, h)
+        expect(response.output.payload.message).to.equal('No data found from users table')
+        expect(response.output.statusCode).to.equal(404)
+      })
+    })
 
     experiment('when data is returned', () => {
       const repoData = [
@@ -61,25 +61,25 @@ experiment('/modules/kpi-reporting/controller', () => {
           external: 2,
           current_year: true
         }
-      ];
+      ]
 
       beforeEach(async () => {
-        sandbox.stub(repos.usersRepo, 'findRegistrationsByMonth').resolves(repoData);
-      });
+        sandbox.stub(repos.usersRepo, 'findRegistrationsByMonth').resolves(repoData)
+      })
       test('returns the correct array of objects', async () => {
-        const { data } = await controller.getRegistrations();
-        expect(data.totals.allTime).to.equal(15);
-        expect(data.totals.ytd).to.equal(12);
-        expect(data.monthly.length).to.equal(3);
-        expect(data.monthly[0].month).to.equal('March');
-        expect(data.monthly[0].internal).to.equal(3);
-        expect(data.monthly[0].external).to.equal(3);
-        expect(data.monthly[0].year).to.equal(new Date().getFullYear());
-        expect(data.monthly[1].month).to.equal('February');
-        expect(data.monthly[1].internal).to.equal(1);
-        expect(data.monthly[1].external).to.equal(1);
-        expect(data.monthly[1].year).to.equal(new Date().getFullYear());
-      });
-    });
-  });
-});
+        const { data } = await controller.getRegistrations()
+        expect(data.totals.allTime).to.equal(15)
+        expect(data.totals.ytd).to.equal(12)
+        expect(data.monthly.length).to.equal(3)
+        expect(data.monthly[0].month).to.equal('March')
+        expect(data.monthly[0].internal).to.equal(3)
+        expect(data.monthly[0].external).to.equal(3)
+        expect(data.monthly[0].year).to.equal(new Date().getFullYear())
+        expect(data.monthly[1].month).to.equal('February')
+        expect(data.monthly[1].internal).to.equal(1)
+        expect(data.monthly[1].external).to.equal(1)
+        expect(data.monthly[1].year).to.equal(new Date().getFullYear())
+      })
+    })
+  })
+})

--- a/test/modules/kpi-reporting/lib/mapper.js
+++ b/test/modules/kpi-reporting/lib/mapper.js
@@ -1,12 +1,12 @@
-'use-strict';
+'use-strict'
 
 const {
   experiment,
   test
-} = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+} = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
-const { mapRegistrations } = require('../../../../src/modules/kpi-reporting/lib/mapper');
+const { mapRegistrations } = require('../../../../src/modules/kpi-reporting/lib/mapper')
 
 experiment('modules/kpi-reporting/lib/mapper', () => {
   const repoData = [
@@ -34,22 +34,22 @@ experiment('modules/kpi-reporting/lib/mapper', () => {
       external: 2,
       current_year: true
     }
-  ];
+  ]
 
   experiment('returns the correct mapped data', () => {
     test('returns the correct array of objects', async () => {
-      const mappedData = mapRegistrations(repoData);
-      expect(mappedData.totals.allTime).to.equal(15);
-      expect(mappedData.totals.ytd).to.equal(12);
-      expect(mappedData.monthly.length).to.equal(3);
-      expect(mappedData.monthly[0].month).to.equal('March');
-      expect(mappedData.monthly[0].internal).to.equal(3);
-      expect(mappedData.monthly[0].external).to.equal(3);
-      expect(mappedData.monthly[0].year).to.equal(new Date().getFullYear());
-      expect(mappedData.monthly[1].month).to.equal('February');
-      expect(mappedData.monthly[1].internal).to.equal(1);
-      expect(mappedData.monthly[1].external).to.equal(1);
-      expect(mappedData.monthly[1].year).to.equal(new Date().getFullYear());
-    });
-  });
-});
+      const mappedData = mapRegistrations(repoData)
+      expect(mappedData.totals.allTime).to.equal(15)
+      expect(mappedData.totals.ytd).to.equal(12)
+      expect(mappedData.monthly.length).to.equal(3)
+      expect(mappedData.monthly[0].month).to.equal('March')
+      expect(mappedData.monthly[0].internal).to.equal(3)
+      expect(mappedData.monthly[0].external).to.equal(3)
+      expect(mappedData.monthly[0].year).to.equal(new Date().getFullYear())
+      expect(mappedData.monthly[1].month).to.equal('February')
+      expect(mappedData.monthly[1].internal).to.equal(1)
+      expect(mappedData.monthly[1].external).to.equal(1)
+      expect(mappedData.monthly[1].year).to.equal(new Date().getFullYear())
+    })
+  })
+})

--- a/test/modules/kpi-reporting/routes.js
+++ b/test/modules/kpi-reporting/routes.js
@@ -1,20 +1,20 @@
-'use strict';
+'use strict'
 
 const {
   experiment,
   test
-} = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
+} = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
 
-const routes = require('../../../src/modules/kpi-reporting/routes');
+const routes = require('../../../src/modules/kpi-reporting/routes')
 
 experiment('modules/kpi-reporting/routes', () => {
   experiment('kpi/registrations', () => {
     test('exports the correct route', async () => {
-      expect(routes[0].path).to.equal('/idm/1.0/kpi/registrations');
-    });
+      expect(routes[0].path).to.equal('/idm/1.0/kpi/registrations')
+    })
     test('publishes a GET method', async () => {
-      expect(routes[0].method).to.equal('GET');
-    });
-  });
-});
+      expect(routes[0].method).to.equal('GET')
+    })
+  })
+})

--- a/test/modules/reauthentication/controller.js
+++ b/test/modules/reauthentication/controller.js
@@ -1,93 +1,93 @@
-const controller = require('../../../src/modules/reauthentication/controller');
-const repos = require('../../../src/lib/repos');
-const helpers = require('../../../src/lib/helpers');
-const { expect } = require('@hapi/code');
-const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script();
-const sinon = require('sinon');
-const sandbox = sinon.createSandbox();
+const controller = require('../../../src/modules/reauthentication/controller')
+const repos = require('../../../src/lib/repos')
+const helpers = require('../../../src/lib/helpers')
+const { expect } = require('@hapi/code')
+const { test, experiment, beforeEach, afterEach } = exports.lab = require('@hapi/lab').script()
+const sinon = require('sinon')
+const sandbox = sinon.createSandbox()
 
-const userId = 123;
+const userId = 123
 
 const createRequest = () => ({
   params: {
-    userId: userId
+    userId
   },
   payload: {
     password: 'test-password'
   }
-});
+})
 
 experiment('reauthentication controller', () => {
-  let h, code, request;
+  let h, code, request
 
   beforeEach(async () => {
-    code = sandbox.stub();
+    code = sandbox.stub()
     h = {
       response: sandbox.stub().returns({ code })
-    };
-    request = createRequest();
+    }
+    request = createRequest()
     sandbox.stub(repos.reauthRepo, 'findByUserId').resolves({
       attempts: 9
-    });
-    sandbox.stub(repos.reauthRepo, 'resetAttemptCounter');
+    })
+    sandbox.stub(repos.reauthRepo, 'resetAttemptCounter')
     sandbox.stub(repos.usersRepo, 'findById').resolves({
       user_id: userId
-    });
-    sandbox.stub(helpers, 'testPassword');
-  });
+    })
+    sandbox.stub(helpers, 'testPassword')
+  })
 
   afterEach(async () => {
-    sandbox.restore();
-  });
+    sandbox.restore()
+  })
 
   experiment('postReauthenticate', () => {
     test('throws a 404 error if user not found', async () => {
-      repos.usersRepo.findById.resolves();
-      await controller.postReauthenticate(request, h);
-      const response = h.response.lastCall.args[0];
-      expect(response.data).to.equal(null);
-      expect(response.error).to.equal('User 123 not found');
-      expect(code.calledWith(404)).to.equal(true);
-    });
+      repos.usersRepo.findById.resolves()
+      await controller.postReauthenticate(request, h)
+      const response = h.response.lastCall.args[0]
+      expect(response.data).to.equal(null)
+      expect(response.error).to.equal('User 123 not found')
+      expect(code.calledWith(404)).to.equal(true)
+    })
 
     test('throws a 429 error if too many incorrect reauthentication attempts', async () => {
       repos.reauthRepo.findByUserId.resolves({
         attempts: 11
-      });
-      await controller.postReauthenticate(request, h);
-      const response = h.response.lastCall.args[0];
-      expect(response.data).to.equal(null);
-      expect(response.error).to.equal('Too many reauthentication attempts - user 123');
-      expect(code.calledWith(429)).to.equal(true);
-    });
+      })
+      await controller.postReauthenticate(request, h)
+      const response = h.response.lastCall.args[0]
+      expect(response.data).to.equal(null)
+      expect(response.error).to.equal('Too many reauthentication attempts - user 123')
+      expect(code.calledWith(429)).to.equal(true)
+    })
 
     test('throws a 401 if incorrect password', async () => {
-      helpers.testPassword.resolves(false);
-      await controller.postReauthenticate(request, h);
-      const response = h.response.lastCall.args[0];
-      expect(response.data).to.equal(null);
-      expect(response.error).to.equal('Incorrect password - user 123');
-      expect(code.calledWith(401)).to.equal(true);
-    });
+      helpers.testPassword.resolves(false)
+      await controller.postReauthenticate(request, h)
+      const response = h.response.lastCall.args[0]
+      expect(response.data).to.equal(null)
+      expect(response.error).to.equal('Incorrect password - user 123')
+      expect(code.calledWith(401)).to.equal(true)
+    })
 
     test('resets attempt counter and responds with user ID if password OK', async () => {
-      helpers.testPassword.resolves(true);
-      const response = await controller.postReauthenticate(request, h);
+      helpers.testPassword.resolves(true)
+      const response = await controller.postReauthenticate(request, h)
       expect(
         repos.reauthRepo.resetAttemptCounter.calledWith(userId)
-      ).to.equal(true);
+      ).to.equal(true)
       expect(response).to.equal({
         data: {
           userId
         },
         error: null
-      });
-    });
+      })
+    })
 
     test('throws unhandled errors', async () => {
-      repos.usersRepo.findById.rejects();
-      const func = () => controller.postReauthenticate(request, h);
-      expect(func()).to.reject();
-    });
-  });
-});
+      repos.usersRepo.findById.rejects()
+      const func = () => controller.postReauthenticate(request, h)
+      expect(func()).to.reject()
+    })
+  })
+})

--- a/test/routes/idm.js
+++ b/test/routes/idm.js
@@ -1,11 +1,11 @@
-const { experiment, test } = exports.lab = require('@hapi/lab').script();
-const { expect } = require('@hapi/code');
-const server = require('../../index');
+const { experiment, test } = exports.lab = require('@hapi/lab').script()
+const { expect } = require('@hapi/code')
+const server = require('../../index')
 
 experiment('/status', () => {
   test('responds with a status code of 200', async () => {
-    const request = { method: 'get', url: '/status' };
-    const response = await server.inject(request);
-    expect(response.statusCode).to.equal(200);
-  });
-});
+    const request = { method: 'get', url: '/status' }
+    const response = await server.inject(request)
+    expect(response.statusCode).to.equal(200)
+  })
+})

--- a/test/routes/user-roles.js
+++ b/test/routes/user-roles.js
@@ -1,26 +1,26 @@
-const Hapi = require('@hapi/hapi');
+const Hapi = require('@hapi/hapi')
 
-const routes = require('../../src/routes/user-roles');
+const routes = require('../../src/routes/user-roles')
 
-const { expect } = require('@hapi/code');
-const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').script();
+const { expect } = require('@hapi/code')
+const { experiment, test, beforeEach } = exports.lab = require('@hapi/lab').script()
 
 const getServer = route => {
-  const server = Hapi.server();
+  const server = Hapi.server()
   const stubbedRoute = {
     ...route,
     handler: () => ({
       testing: true
     })
-  };
-  server.route(stubbedRoute);
-  return server;
-};
+  }
+  server.route(stubbedRoute)
+  return server
+}
 
 experiment('routes/user-roles', () => {
   experiment('PUT user/{userId}/roles', () => {
-    let request;
-    let server;
+    let request
+    let server
 
     beforeEach(async () => {
       request = {
@@ -31,44 +31,44 @@ experiment('routes/user-roles', () => {
           roles: ['RoleA'],
           groups: ['GroupA', 'GroupB']
         }
-      };
+      }
 
-      server = getServer(routes[0]);
-    });
+      server = getServer(routes[0])
+    })
 
     test('calls the controller hanlder for a valid request', async () => {
-      const response = await server.inject(request);
-      expect(response.result.testing).to.be.true();
-    });
+      const response = await server.inject(request)
+      expect(response.result.testing).to.be.true()
+    })
 
     test('returns a 400 for an invalid user id', async () => {
-      request.url = '/idm/1.0/user/not-an-integer/roles';
-      const response = await server.inject(request);
-      expect(response.statusCode).to.equal(400);
-    });
+      request.url = '/idm/1.0/user/not-an-integer/roles'
+      const response = await server.inject(request)
+      expect(response.statusCode).to.equal(400)
+    })
 
     test('returns a 400 for an invalid application', async () => {
-      request.payload.application = 123;
-      const response = await server.inject(request);
-      expect(response.statusCode).to.equal(400);
-    });
+      request.payload.application = 123
+      const response = await server.inject(request)
+      expect(response.statusCode).to.equal(400)
+    })
 
     test('returns a 400 for a missing application', async () => {
-      delete request.payload.application;
-      const response = await server.inject(request);
-      expect(response.statusCode).to.equal(400);
-    });
+      delete request.payload.application
+      const response = await server.inject(request)
+      expect(response.statusCode).to.equal(400)
+    })
 
     test('returns a 400 for an invalid list of roles', async () => {
-      request.payload.roles = [1, 2, 3];
-      const response = await server.inject(request);
-      expect(response.statusCode).to.equal(400);
-    });
+      request.payload.roles = [1, 2, 3]
+      const response = await server.inject(request)
+      expect(response.statusCode).to.equal(400)
+    })
 
     test('returns a 400 for an invalid list of groups', async () => {
-      request.payload.groups = [1, 2, 3];
-      const response = await server.inject(request);
-      expect(response.statusCode).to.equal(400);
-    });
-  });
-});
+      request.payload.groups = [1, 2, 3]
+      const response = await server.inject(request)
+      expect(response.statusCode).to.equal(400)
+    })
+  })
+})

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -1,30 +1,30 @@
-require('dotenv').config();
-const { pool } = require('../src/lib/connectors/db');
+require('dotenv').config()
+const { pool } = require('../src/lib/connectors/db')
 
 const createUser = async (username, password, application) => {
   const query = `
     insert into idm.users (user_name, password, application)
     values ($1, $2, $3)
-    returning *;`;
+    returning *;`
 
-  const { rows } = await pool.query(query, [username, password, application]);
+  const { rows } = await pool.query(query, [username, password, application])
 
-  return rows[0];
-};
+  return rows[0]
+}
 
 const deleteUser = async userID => {
-  const query = 'delete from idm.users where user_id = $1;';
-  return pool.query(query, [userID]);
-};
+  const query = 'delete from idm.users where user_id = $1;'
+  return pool.query(query, [userID])
+}
 
 const deleteTestUsers = () => {
   // eslint-disable-next-line quotes
-  const query = `DELETE FROM idm.users WHERE user_data->>'unitTest'='true'`;
-  return pool.query(query);
-};
+  const query = `DELETE FROM idm.users WHERE user_data->>'unitTest'='true'`
+  return pool.query(query)
+}
 
 module.exports = {
   createUser,
   deleteUser,
   deleteTestUsers
-};
+}

--- a/test/users.js
+++ b/test/users.js
@@ -7,33 +7,33 @@
  * - Verify with auth code
  * - Update documents with verification ID to verified status
  */
-'use strict';
-const { v4: uuid } = require('uuid');
-const { experiment, test, beforeEach, after } = exports.lab = require('@hapi/lab').script();
-const { get } = require('lodash');
-const { expect } = require('@hapi/code');
-const server = require('../index');
-const { deleteTestUsers } = require('./test-helpers');
+'use strict'
+const { v4: uuid } = require('uuid')
+const { experiment, test, beforeEach, after } = exports.lab = require('@hapi/lab').script()
+const { get } = require('lodash')
+const { expect } = require('@hapi/code')
+const server = require('../index')
+const { deleteTestUsers } = require('./test-helpers')
 
 // A user is always created with testEmailOne as part of the beforeEach.
-const testEmailOne = 'test1@example.com';
+const testEmailOne = 'test1@example.com'
 
 // This is reserved when needing to add an alternative/extra user
-const testEmailTwo = 'test2@example.com';
+const testEmailTwo = 'test2@example.com'
 
 // A list of test user IDs
-const testUserIds = [];
+const testUserIds = []
 
 const createRequest = (method = 'GET', url = '/idm/1.0/user') => ({
   method,
   url,
   headers: { Authorization: process.env.JWT_TOKEN }
-});
+})
 
-const createGetRequest = id => createRequest('GET', `/idm/1.0/user/${id}`);
+const createGetRequest = id => createRequest('GET', `/idm/1.0/user/${id}`)
 
 const createTestUser = async (userName = testEmailOne, application = 'water_vml') => {
-  const request = createRequest('POST');
+  const request = createRequest('POST')
   request.payload = {
     user_name: userName,
     application,
@@ -41,79 +41,79 @@ const createTestUser = async (userName = testEmailOne, application = 'water_vml'
     user_data: JSON.stringify({
       unitTest: true
     })
-  };
-
-  const response = await server.inject(request);
-
-  // Store generated user ID
-  const data = JSON.parse(response.payload);
-  const userId = get(data, 'data.user_id');
-  if (userId) {
-    testUserIds.push(userId);
   }
 
-  return response;
-};
+  const response = await server.inject(request)
+
+  // Store generated user ID
+  const data = JSON.parse(response.payload)
+  const userId = get(data, 'data.user_id')
+  if (userId) {
+    testUserIds.push(userId)
+  }
+
+  return response
+}
 
 experiment('Test users API', () => {
   // Always add the basic test user to the database before each
   // to simplify GET based tests
   beforeEach(async ({ context }) => {
-    await deleteTestUsers();
-    const response = await createTestUser();
-    const payload = JSON.parse(response.payload);
-    context.userId = payload.data.user_id;
-  });
+    await deleteTestUsers()
+    const response = await createTestUser()
+    const payload = JSON.parse(response.payload)
+    context.userId = payload.data.user_id
+  })
 
   after(async () => {
-    await deleteTestUsers();
-  });
+    await deleteTestUsers()
+  })
 
   test('The API should create a user', async ({ context }) => {
-    const res = await createTestUser(testEmailTwo);
-    expect(res.statusCode).to.equal(201);
+    const res = await createTestUser(testEmailTwo)
+    expect(res.statusCode).to.equal(201)
 
-    const payload = JSON.parse(res.payload);
+    const payload = JSON.parse(res.payload)
 
-    expect(payload.error).to.equal(null);
-    expect(payload.data.user_id).to.be.a.number();
-    expect(payload.data.user_name).to.equal(testEmailTwo);
-    expect(payload.data.date_created).to.be.a.string();
-    expect(payload.data.date_updated).to.be.a.string();
-  });
+    expect(payload.error).to.equal(null)
+    expect(payload.data.user_id).to.be.a.number()
+    expect(payload.data.user_name).to.equal(testEmailTwo)
+    expect(payload.data.date_created).to.be.a.string()
+    expect(payload.data.date_updated).to.be.a.string()
+  })
 
   test('The API should get a user by ID', async ({ context }) => {
-    const request = createGetRequest(context.userId);
-    const response = await server.inject(request);
-    expect(response.statusCode).to.equal(200);
+    const request = createGetRequest(context.userId)
+    const response = await server.inject(request)
+    expect(response.statusCode).to.equal(200)
 
     // Check payload
-    const { error, data } = JSON.parse(response.payload);
+    const { error, data } = JSON.parse(response.payload)
 
-    expect(error).to.equal(null);
-    expect(data.user_name).to.equal(testEmailOne);
-  });
+    expect(error).to.equal(null)
+    expect(data.user_name).to.equal(testEmailOne)
+  })
 
   test('The API should get a list of users', async () => {
-    const request = createRequest();
-    const response = await server.inject(request);
-    expect(response.statusCode).to.equal(200);
+    const request = createRequest()
+    const response = await server.inject(request)
+    expect(response.statusCode).to.equal(200)
 
-    const payload = JSON.parse(response.payload);
-    expect(payload.error).to.equal(null);
-    expect(payload.data).to.be.an.array();
-  });
+    const payload = JSON.parse(response.payload)
+    expect(payload.error).to.equal(null)
+    expect(payload.data).to.be.an.array()
+  })
 
   test('It is not be possible to use the same email with one application', async () => {
-    await createTestUser(testEmailTwo, 'water_vml');
-    const response = await createTestUser(testEmailTwo, 'water_vml');
-    expect(response.statusCode).to.equal(400);
-  });
+    await createTestUser(testEmailTwo, 'water_vml')
+    const response = await createTestUser(testEmailTwo, 'water_vml')
+    expect(response.statusCode).to.equal(400)
+  })
 
   test('It is possible to use the same email with across applications', async () => {
-    const createVmlResponse = await createTestUser(testEmailTwo, 'water_vml');
-    const createAdminResponse = await createTestUser(testEmailTwo, 'water_admin');
-    expect(createVmlResponse.statusCode).to.equal(201);
-    expect(createAdminResponse.statusCode).to.equal(201);
-  });
-});
+    const createVmlResponse = await createTestUser(testEmailTwo, 'water_vml')
+    const createAdminResponse = await createTestUser(testEmailTwo, 'water_admin')
+    expect(createVmlResponse.statusCode).to.equal(201)
+    expect(createAdminResponse.statusCode).to.equal(201)
+  })
+})


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/9

Defra's JavaScript standard is to use StandardJS for linting. We currently use ESLint, configured to Semi-Standard (ie. StandardJS with semicolons). For consistency, we should change this to the regular Standard rules, and replace ESLint with StandardJS while we're at it.