### PR TITLE
Apply consistent CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,51 +1,33 @@
 name: CI
 
-
-on:
-  push:
-    branches:
-      - '**'
-      - '!dependabot/**'
+on: push
 
 jobs:
-  base-node-pipeline:
-    uses: DEFRA/water-abstraction-orchestration/.github/workflows/base-node-pipeline.yml@develop
-    with:
-      serviceName: DEFRA_water-abstraction-tactical-idm
-    secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-  docker-build-and-push-image:
-    uses: DEFRA/water-abstraction-orchestration/.github/workflows/docker.yml@develop
-  test:
+  build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [ 14.x, 16.x ]
-    name: Test  - Node.js ${{ matrix.node-version }}
     env:
-      # These need to be duplicated in services section for postgres. Unfortunately, there is not a way to reuse them
-      PGUSER: water
-      PGHOST: localhost
-      PGPASSWORD: water
-      PGPORT: 5432
-      PGDATABASE: water
       ENVIRONMENT: dev
-      DATABASE_URL: postgres://water:water@localhost:5432/water
-      JWT_SECRET: secret
-      JWT_TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTIzNH0.MOREC6-Kszb9bDFw0O1UKywpnkcP-c5cPjASMpjk8Po
-      NOTIFY_KEY: somerealnotifykey-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000
+      DATABASE_URL: postgres://water_user:password@localhost:5432/wabs
+      JWT_SECRET: ItsNoSecretBecauseYouToldEverybody
+      JWT_TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwibmFtZSI6InRlc3QiLCJpYXQiOjE1MDMzMTg0NDV9.eWghqjYlPrb8ZjWacYzTCTh1PBtr2BeSv-_ZIwrtmwE
+      # These need to be duplicated in services section for postgres. Unfortunately, there is not a way to reuse them
+      PGUSER: water_user
+      PGPASSWORD: password
+      PGDATABASE: wabs
+      PGHOST: localhost
+      PGPORT: 5432
 
     # Service containers to run with `runner-job`
     services:
       # Label used to access the service container
       postgres:
         # Docker Hub image
-        image: postgres:10-alpine
+        image: postgres:12-alpine
         # Provide the password for postgres
         env:
-          POSTGRES_USER: water
-          POSTGRES_DB: water
-          POSTGRES_PASSWORD: water
+          POSTGRES_USER: water_user
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: wabs
         # Maps tcp port 5432 on service container to the host
         ports:
           - 5432:5432
@@ -54,24 +36,72 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      # Downloads a copy of the code in your repository before running CI tests
+      - name: Checkout repository
+        uses: actions/checkout@v3
         with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-      - name: Install node modules
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
+
+      # Before we do anything, check we haven't accidentally left any `experiment.only()` or `test.only(` statements in
+      # the tests
+      #
+      # Reworking of https://stackoverflow.com/a/21788642/6117745
+      - name: Temporary tag check
         run: |
-          npm ci
-      - name: Create database
+          ! grep -R 'experiment.only(\|test.only(' test
+
+      # Our projects use .nvmrc files to specify the node version to use. We can read and then output it as the result
+      # this step. Subsequent steps can then access the value
+      - name: Read Node version
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        # Give the step an ID to make it easier to refer to
+        id: nvm
+
+      # Gets the version to use by referring to the previous step
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+
+      # Speeds up workflows by reading the node modules from cache. Obviously you need to run it at least once, and the
+      # cache will be updated should the package-lock.json file change
+      - name: Cache Node modules
+        uses: actions/cache@v3
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
+
+      # Performs a clean installation of all dependencies in the `package.json` file
+      # For more information, see https://docs.npmjs.com/cli/ci.html
+      - name: Install dependencies
+        run: npm ci
+
+      # Run linting first. No point running the tests if there is a linting issue
+      - name: Run lint check
         run: |
-          PGPASSWORD=water psql -U water -tc "SELECT 'CREATE DATABASE water' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'water')"
-      - name: Run database migrations
+          npm run lint
+
+      - name: Database migrations
         run: |
           npm run migrate
-      - name: Test & publish code coverage
-        uses: paambaati/codeclimate-action@v2.7.4
+
+      # This includes an extra run step. The sonarcloud analysis will be run in a docker container with the current
+      # folder mounted as `/github/workspace`. The problem is when the lcov.info file is generated it will reference the
+      # code in the current folder. So to enable sonarcloud to matchup code coverage with the files we use sed to update
+      # the references in lcov.info
+      # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/6
+      - name: Run unit tests
+        run: |
+          npm test
+          sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' coverage/lcov.info
+
+      - name: Analyze with SonarCloud
+        if: github.actor != 'dependabot[bot]'
+        uses: sonarsource/sonarcloud-github-action@master
         env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        with:
-          coverageCommand: npm run test:ci
-          debug: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets

--- a/.labrc.js
+++ b/.labrc.js
@@ -1,15 +1,16 @@
+'use strict'
 // default settings for lab test runs.
 //
 // This is overridden if arguments are passed to lab via the command line.
 module.exports = {
-  // This version global seems to be introduced by sinon.
-  globals: 'version,fetch,Response,Headers,Request',
   verbose: true,
-  'coverage-exclude': [
-    'src/lib/logger/vendor',
-    'scripts',
-    'node_modules',
-    'migrations',
-    'test'
-  ]
+  coverage: true,
+  // Means when we use *.only() in our tests we just get the output for what we've flagged rather than all output but
+  // greyed out to show it was skipped
+  'silent-skips': true,
+  // lcov reporter required for SonarCloud
+  reporter: ['console', 'html', 'lcov'],
+  output: ['stdout', 'coverage/coverage.html', 'coverage/lcov.info'],
+  // This version global seems to be introduced by sinon.
+  globals: ['version', 'fetch', 'Response', 'Headers', 'Request'].join(',')
 };

--- a/README.MD
+++ b/README.MD
@@ -1,12 +1,11 @@
+# Water Abstraction Tactical IDM
 
-|               |              |  
-|---------------|--------------|
-| Build         |  ![CI](https://github.com/DEFRA/water-abstraction-tactical-idm/workflows/CI/badge.svg) |
-| Test coverage |[![Test Coverage](https://api.codeclimate.com/v1/badges/40d67aaf281ad5123107/test_coverage)](https://codeclimate.com/github/DEFRA/water-abstraction-tactical-idm/test_coverage)  |
-| Quality check |  [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_water-abstraction-tactical-idm&metric=alert_status)](https://sonarcloud.io/dashboard?id=DEFRA_water-abstraction-tactical-idm) |
+![Build Status](https://github.com/DEFRA/water-abstraction-tactical-idm/workflows/CI/badge.svg?branch=develop)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_water-abstraction-tactical-idm&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=DEFRA_water-abstraction-tactical-idm)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_water-abstraction-tactical-idm&metric=coverage)](https://sonarcloud.io/dashboard?id=DEFRA_water-abstraction-tactical-idm)
+[![Known Vulnerabilities](https://snyk.io/test/github/DEFRA/water-abstraction-tactical-idm/badge.svg)](https://snyk.io/test/github/DEFRA/water-abstraction-tactical-idm)
+[![Licence](https://img.shields.io/badge/Licence-OGLv3-blue.svg)](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3)
 
-
-# Introduction
 This component is one of 3 that combine to give you the ability to store a document or details of a permit or pass, to link those documents to users that can view and be able to have different access for internal and external users. With a front end it will enable most processes to capture, share and view details of permits and or licence style information
 
 __Permit Repository:__ https://github.com/DEFRA/water-abstraction-permit-repository
@@ -14,8 +13,6 @@ __Permit Repository:__ https://github.com/DEFRA/water-abstraction-permit-reposit
 __IDM:__ https://github.com/DEFRA/water-abstraction-tactical-idm
 
 __CRM:__ https://github.com/DEFRA/water-abstraction-tactical-crm
-
-# water-abstraction-tactical-idm
 
 The water-abstraction-tactical-idm is a lightweight identity management solution providing simple user account creation and authentication features.
 
@@ -72,4 +69,3 @@ It is designed to encourage use and re-use of information freely and flexibly, w
 ## Environment Variables
 
 The required environment variables for local development can be found in the [.env.example file](./.env.example).
-

--- a/package.json
+++ b/package.json
@@ -9,8 +9,6 @@
   },
   "scripts": {
     "test": "lab",
-    "test:ci": "lab -t 55 -m 0 -r lcov -o coverage/lcov.info -r console -o stdout",
-    "test-cov-html": "lab -r html -o coverage.html",
     "migrate": "node scripts/create-schema && db-migrate up --verbose",
     "migrate:down": "db-migrate down --verbose",
     "migrate:create": "db-migrate create --sql-file --",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,34 @@
+# Reference for all available properties
+# https://sonarcloud.io/documentation/analysis/analysis-parameters/
+# Reference for how to glob files
+# https://docs.sonarqube.org/latest/project-administration/narrowing-the-focus/
+
+# Project key is required. You'll find it in the SonarCloud UI
+sonar.projectKey=DEFRA_water-abstraction-tactical-idm
+sonar.organization=defra
+
+# This is the name and version displayed in the SonarCloud UI.
+sonar.projectName=water-abstraction-tactical-idm
+
+# This will add the same links in the SonarCloud UI
+sonar.links.homepage=https://github.com/DEFRA/water-abstraction-tactical-idm
+sonar.links.ci=https://github.com/DEFRA/water-abstraction-retutactical-idmrns/actions
+sonar.links.scm=https://github.com/DEFRA/water-abstraction-tactical-idm
+sonar.links.issue=https://github.com/DEFRA/water-abstraction-team/issues
+
+# Path is relative to the sonar-project.properties file.
+# SonarCloud seems to have little intelligence when it comes to code coverage. Quite simply if it sees a code file, it
+# checks it against our coverage report and if not found flags it as uncovered. This also effects the overall coverage
+# score. In our case this means SonarCloud could flag everything under test/ as lacking code coverage!
+# We have found this combinations of `sources`, `tests` and `tests.inclusions` means SonarCloud properly understands
+# what is code and what is a test file. Note the use of ./ in `sources`. This is the only way we found to include root
+# level files and ensure they are correctly resolved when SonarCloud scans the lcov coverage data.
+sonar.sources=src,./config.js,./index.js
+sonar.tests=test
+sonar.test.inclusions=test/**/*.js
+
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8
+
+# Ensure SonarCloud knows where to pick up test coverage stats
+sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/4

As a team, we are currently maintaining 11 repos and that's not including documentation, support and deployment-related stuff! What we inherited was not consistent; different CI tools were used for the same purpose and different CI steps were implemented.

An effort was made to get this under control with [water-abstraction-orchestration](https://github.com/DEFRA/water-abstraction-orchestration). But to get a handle on it in such a way as the current team can manage, we're simplifying still further.

This change updates `.github/workflows/ci.yml` to use a template we're applying across all the repos, amended to the requirements of the project. In the future, we hope to return to the lessons **water-abstraction-orchestration** taught us, if only to remove the duplication across the projects. But for now, the template hopefully simplifies and makes consistent our build process.

**Notes**

- Apply ci.yml template

This is very much based on https://github.com/DEFRA/sroc-charging-module-api/blob/main/.github/workflows/ci.yml

There is now one process, which means you'll just see the one item listed in the checks on GitHub. The steps are ordered in an effort to fail fast and/or where needed, for example, DB migrations before running tests and SonarCloud analysis after code coverage data has been generated.

- Update .labrc

This is based on https://github.com/DEFRA/sroc-charging-module-api/blob/main/.labrc.js. We use the config file to ensure we generate the coverage output in a format needed by SonarCloud.

- Add SonarCloud properties file

Previously, the CI specified the values SonarCloud needs in its steps plus there were some in the web UI. But there are a bunch of other things we can tell SonarCloud about which makes managing SonarCloud much easier.

So, we use `sonar-project.properties` files to set what the SonarCloud analysis step needs and what's useful in its UI.

- Update README with new badges

Also displays the badges we want in a layout that is consistent with most open source repos.