### PR TITLE
Correctly set NODE_ENV

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,13 +9,13 @@ ERRBIT_KEY=
 ERRBIT_SERVER=
 
 SLACK_HOOK=
-NODE_ENV=
 
 BASE_URL=
 
 WATER_URI=
 
-NODE_ENV=local
+NODE_ENV=production
+ENVIRONMENT=pre
 
 # Set log level for app. Default is 'info'
 WRLS_LOG_LEVEL=debug

--- a/config.js
+++ b/config.js
@@ -53,7 +53,7 @@ module.exports = {
   //
   pg: {
     connectionString: process.env.DATABASE_URL,
-    max: process.env.NODE_ENV === 'local' ? 20 : 5,
+    max: 5,
     idleTimeoutMillis: 10000,
     connectionTimeoutMillis: 5000
   },

--- a/config.js
+++ b/config.js
@@ -1,4 +1,7 @@
-const isAcceptanceTestTarget = ['local', 'dev', 'development', 'test', 'qa', 'preprod'].includes(process.env.NODE_ENV)
+'use strict'
+
+const environment = process.env.ENVIRONMENT
+const isProduction = environment === 'prd'
 
 module.exports = {
   version: '1.0',
@@ -64,5 +67,5 @@ module.exports = {
     water_admin: process.env.ADMIN_BASE_URL || 'http://127.0.0.1:8008'
   },
 
-  isAcceptanceTestTarget
+  isProduction
 }

--- a/src/modules/acceptance-tests/controller.js
+++ b/src/modules/acceptance-tests/controller.js
@@ -6,13 +6,13 @@ const deleteAcceptanceTestData = async (request, h) => {
   await pool.query(`
     delete
     from idm.users
-    where user_data->>'source' = '${ACCEPTANCE_TEST_SOURCE}' 
+    where user_data->>'source' = '${ACCEPTANCE_TEST_SOURCE}'
     or user_name like '%@example.com';
   `)
 
   return h.response().code(204)
 }
 
-if (config.isAcceptanceTestTarget) {
+if (!config.isProduction) {
   exports.deleteAcceptanceTestData = deleteAcceptanceTestData
 }

--- a/src/modules/acceptance-tests/routes.js
+++ b/src/modules/acceptance-tests/routes.js
@@ -1,7 +1,7 @@
 const config = require('../../../config')
 const controller = require('./controller')
 
-if (config.isAcceptanceTestTarget) {
+if (!config.isProduction) {
   exports.acceptanceTestTearDown = {
     method: 'DELETE',
     path: `/idm/${config.version}/acceptance-tests`,


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/43

We are currently using `NODE_ENV` incorrectly; we set it to be the name of the specific environment (eg. `local`, `qa` etc.) when it should be more like the _type_ of environment (e.g. is it a dev environment, a production environment, etc.)

This means that tools like pm2 aren't correctly picking up that we are running in a dev-like or prod-like environment and configuring accordingly.

We, therefore, change how we use `NODE_ENV` to be the type of environment, with a separate `ENVIRONMENT` env var to set the actual environment (eg. `tst`, `pre` etc.)