### PR TITLE
Stop passing err to logger

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ const init = async () => {
 }
 
 const processError = message => err => {
-  logger.error(message, err)
+  logger.error(message, err.stack)
   process.exit(1)
 }
 

--- a/src/controllers/reset.js
+++ b/src/controllers/reset.js
@@ -53,7 +53,7 @@ const errorHandler = (request, h, error) => {
     return h.response({ data: null, error }).code(404)
   }
 
-  logger.error('resetPassword error', error)
+  logger.error('resetPassword error', error.stack)
   return h.response({ data: null, error }).code(500)
 }
 

--- a/src/lib/connectors/water.js
+++ b/src/lib/connectors/water.js
@@ -16,7 +16,7 @@ const sendNotifyMessage = async (messageRef, recipient, personalisation = {}) =>
     const response = await helpers.serviceRequest.post(uri, options)
     return response
   } catch (err) {
-    logger.error('Error sending notify message', err)
+    logger.error('Error sending notify message', err.stack)
     throw err
   }
 }

--- a/src/modules/authenticate/controller.js
+++ b/src/modules/authenticate/controller.js
@@ -23,7 +23,7 @@ const errorHandler = (err, h) => {
       err: 'Unknown user name or password'
     }).code(401)
   }
-  logger.error('IDM login error', err)
+  logger.error('IDM login error', err.stack)
   throw err
 }
 


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/45

Here we are trying to make the error logs more usable. Currently when an error happens the logs are getting jammed up with thousands of lines making them difficult to read and unusable. This change stops that pollution making them more usable.