### PR TITLE
Replace deprecated set-output cmd in GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       # Our projects use .nvmrc files to specify the node version to use. We can read and then output it as the result
       # this step. Subsequent steps can then access the value
       - name: Read Node version
-        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        run: echo "{NVMRC}={cat .nvmrc}" >> $GITHUB_OUTPUT
         # Give the step an ID to make it easier to refer to
         id: nvm
 


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/56

Here we are saving the node version into an environment variable to then be read by the github CI as set-output has been deprecated.