### PR TITLE
Remove verbose from db migrate commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "license": "OGL-UK-3.0",
   "scripts": {
     "test": "lab",
-    "migrate": "node scripts/create-schema && db-migrate up --verbose",
-    "migrate:down": "db-migrate down --verbose",
+    "migrate": "node scripts/create-schema && db-migrate up",
+    "migrate:down": "db-migrate down",
     "migrate:create": "db-migrate create --sql-file --",
     "lint": "standard",
     "version": "npx --yes auto-changelog -p --commit-limit false && git add CHANGELOG.md"


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/65

We needed to add a large data migration to fix an issue. The fix worked but it broke CI. GitHub actions started erroring when the migrations ran with `##[error]stderr maxBuffer length exceeded`.

Unlike locally, where only the latest migrations are run, in CI all migrations are run all the time and our 2.5k SQL script (😳 😁 ) was obviously the straw that broke the camel's back.

We realised that so much was outputting because all our migration scripts have the `--verbose` flag set. When we removed it in this case, the problem was solved.

We don't need to see it, and it might avoid the same problem from happening to other repos. So, this issue is about going through the repos and removing `--verbose` from any migrate commands.