### PR TITLE
Removing console.log() from legacy migrations

### DIFF
--- a/migrations/20171201101811-idm.js
+++ b/migrations/20171201101811-idm.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20171213091237-unique-username.js
+++ b/migrations/20171213091237-unique-username.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20171214130749-fix-timestamp-login.js
+++ b/migrations/20171214130749-fix-timestamp-login.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20171218084708-setup-wab-team.js
+++ b/migrations/20171218084708-setup-wab-team.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180131092635-add-user-type.js
+++ b/migrations/20180131092635-add-user-type.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180430144211-add-kpi-reports.js
+++ b/migrations/20180430144211-add-kpi-reports.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180501124503-fix-daves-stoopid.js
+++ b/migrations/20180501124503-fix-daves-stoopid.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180712131745-change-user-data-type.js
+++ b/migrations/20180712131745-change-user-data-type.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180718133110-users-add-roles-and-application.js
+++ b/migrations/20180718133110-users-add-roles-and-application.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180718214743-users-composite-unique-constraint.js
+++ b/migrations/20180718214743-users-composite-unique-constraint.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180720134957-set-user-application-and-remove-admin.js
+++ b/migrations/20180720134957-set-user-application-and-remove-admin.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180724104315-users-add-external-id.js
+++ b/migrations/20180724104315-users-add-external-id.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20181108142402-users-add-reset-guid-date-created.js
+++ b/migrations/20181108142402-users-add-reset-guid-date-created.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20190605101404-internal-users-to-new-application-name.js
+++ b/migrations/20190605101404-internal-users-to-new-application-name.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20190703092645-change-email-verification.js
+++ b/migrations/20190703092645-change-email-verification.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20190729144004-user-groups.js
+++ b/migrations/20190729144004-user-groups.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20190730143144-cleanup-test-users.js
+++ b/migrations/20190730143144-cleanup-test-users.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20190802120734-change-email-attempts-count.js
+++ b/migrations/20190802120734-change-email-attempts-count.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20190807163156-reauth.js
+++ b/migrations/20190807163156-reauth.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20190808125024-email-change.js
+++ b/migrations/20190808125024-email-change.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20190816131841-enabled-users.js
+++ b/migrations/20190816131841-enabled-users.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20190827110406-alter-pgcryto-extension-schema.js
+++ b/migrations/20190827110406-alter-pgcryto-extension-schema.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20190828155617-new-charging-role.js
+++ b/migrations/20190828155617-new-charging-role.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20191127111358-new-billing-role.js
+++ b/migrations/20191127111358-new-billing-role.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20200116122318-roles-based-indexes.js
+++ b/migrations/20200116122318-roles-based-indexes.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20200820074624-add-charge-version-workflow-roles.js
+++ b/migrations/20200820074624-add-charge-version-workflow-roles.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20200923143302-agreements-roles.js
+++ b/migrations/20200923143302-agreements-roles.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20201016094050-allow-billing-and-data-to-edit-charge-workflows.js
+++ b/migrations/20201016094050-allow-billing-and-data-to-edit-charge-workflows.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20201117151936-billing-account-roles.js
+++ b/migrations/20201117151936-billing-account-roles.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20210611125925-create-waa-role.js
+++ b/migrations/20210611125925-create-waa-role.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20210623091731-nps-psc-charging-permissions.js
+++ b/migrations/20210623091731-nps-psc-charging-permissions.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/91

This PR is focusing on removing console.log() from legacy migrations as per Teams issue. When working on DEFRA/water-abstraction-service#2227 we again broke GitHub CI because of the volume of output from our migrations.

In DEFRA/water-abstraction-team#65 we thought we'd dealt with the issue believing that db-mgrate's verbose() argument was to blame.

Looking into the issue in the stuck bill run we came across a db-migrate/node-db-migrate#453 (comment) that gave us a 🤦 !

The db-migrate template used when generating migrations includes a console.log() that outputs the migration file read in. So, though we might not be outputting all the SQL being fired, we are still outputting the contents of every single migration file!

We definitely don't need to see this and it should remove the chance of us breaking the build in this way once and for all.

So, this issue is about going into the existing migrations and removing the 2 console.log('received data: ' + data) lines in each across all repos.