### PR TITLE
Fix external change user email journey

### DIFF
--- a/src/modules/change-email/controller.js
+++ b/src/modules/change-email/controller.js
@@ -46,6 +46,7 @@ const getStatus = async (request, h) => {
       data: {
         userId,
         email: data.new_email_address,
+        securityCode: data.security_code,
         isLocked: isLocked(data)
       },
       error: null

--- a/src/modules/change-email/controller.js
+++ b/src/modules/change-email/controller.js
@@ -76,7 +76,9 @@ const postStartEmailChange = async (request, h) => {
     // Rate limit requests
     const existing = await repos.changeEmailRepo.findOneByUserId(userId)
 
-    validateEmailChange(userId, existing)
+    if (existing) {
+      validateEmailChange(userId, existing)
+    }
 
     // Upsert email change record
     const data = await repos.changeEmailRepo.create(userId, email)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4632

We received a report that the external app's change email journey was broken. We quickly confirmed this.

The problem was this section in `src/modules/change-email/controller.js`.

```javascript
const postStartEmailChange = async (request, h) => {
  const { userId } = request.params
  const { email } = request.payload

  try {
    // Rate limit requests
    const existing = await repos.changeEmailRepo.findOneByUserId(userId)

    validateEmailChange(userId, existing)

    // Upsert email change record
    const data = await repos.changeEmailRepo.create(userId, email)

    // ...
```

The controller was essentially rebuilt in [Bugfix/water 2188 further work](https://github.com/DEFRA/water-abstraction-tactical-idm/pull/281) (Aug 2019), and then it was left like this.

The idea of the `validateEmailChange()` call is to ensure that the retry limit (which they named rate limit) has not been hit and the user has been re-authenticated (the journey requires you to re-enter your password). It does this using the data returned by `await repos.changeEmailRepo.findOneByUserId(userId)`.

But hold up, when does the record that holds the data being validated get created? That's right, after the validation call! (`const data = await repos.changeEmailRepo.create(userId, email)`)

Any user attempting to change their email will find it blows up because `existing` never contains anything. This means the feature has never worked since the 'bugfix' was implemented. 😱🤦

So, in this change, we do 2 things.

- we only call `validateEmailChange()` if we have something to validate
- we tweak the `getStatus()` handler to include the security code needed to verify the email change

That second change relates to work we've done to support [Adding an external user change email test](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/131) to our automated test suite. Hopefully, if we break it, we'll spot the problem sooner than 5 years. 😜