### PR TITLE
Switch to using Snyk CLI action in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets
+
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,40 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-COOKIE-8163060:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-06T08:52:10.645Z
+        created: 2025-08-07T08:52:10.648Z
+  SNYK-JS-JSONWEBTOKEN-3180022:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-06T08:52:51.434Z
+        created: 2025-08-07T08:52:51.440Z
+  SNYK-JS-JSONWEBTOKEN-3180024:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-06T08:53:40.944Z
+        created: 2025-08-07T08:53:40.950Z
+  SNYK-JS-JSONWEBTOKEN-3180026:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-06T08:54:04.425Z
+        created: 2025-08-07T08:54:04.431Z
+  SNYK-JS-FORMDATA-10841150:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2025-09-06T08:54:54.179Z
+        created: 2025-08-07T08:54:54.183Z
+  SNYK-JS-REQUEST-3361831:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2025-09-06T08:55:15.071Z
+        created: 2025-08-07T08:55:15.077Z
+  SNYK-JS-TOUGHCOOKIE-5672873:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2025-09-06T08:55:41.445Z
+        created: 2025-08-07T08:55:41.451Z
+patch: {}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5191

With the adoption of SSO in the Defra GitHub org, our current [Snyk](https://snyk.io) status checks have stopped working.

The [team issue](https://github.com/DEFRA/water-abstraction-team/issues/144) goes into more detail, but in essence, whilst the GitHub account that **Snyk** uses to connect has SSO enabled, it won't connect to GitHub to update the PR with the test result.

This change performs the same check without **Snyk** having to authenticate to GitHub. Instead, GitHub will authenticate with **Snyk** by using its CLI via a GitHub action.

It does mean **Snyk** will no longer be listed as a separate check; instead, it will just be a new step in our CI. So, the outcome (adding a package with a vulnerability will cause the PR to fail checks) will be the same.