### PR TITLE
Add GitHub action dependency-review-action to our CI

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,24 @@
+name: Dependency Review
+
+on: pull_request
+
+permissions:
+  contents: read
+  # Required when using the "comment-summary-in-pr" option
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
+
+      # Scans your pull requests for dependency changes, and will raise an error if any vulnerabilities or invalid
+      # licenses are being introduced.
+      - name: Dependency Review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 #v5.0.0
+        with:
+          fail-on-severity: moderate
+          comment-summary-in-pr: on-failure


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5679

Add the GitHub action `dependency-review-action` to the repo.

Set the `fail-on-severity option` to `moderate` and the `comment-summary-in-pr` to `on-failure`.