### PR TITLE
Fix failing test

### DIFF
--- a/.labrc.js
+++ b/.labrc.js
@@ -18,6 +18,7 @@ module.exports = {
     'Response',
     'Headers',
     'Request',
-    'Symbol(undici.globalDispatcher.1)'
+    'Symbol(undici.globalDispatcher.1)',
+    'Symbol(undici.globalDispatcher.2)'
   ].join(',')
 };


### PR DESCRIPTION
## Fix failing test run caused by undici global dispatcher leak

### The problem

`npm test` recently started failing with exit code `1`, even though every test appears to pass. The run ends with:

> `The following leaks were detected: Symbol(undici.globalDispatcher.2)`

### Root cause

The test assertions were never actually failing — all 129 tests pass (✔). The run was failing purely because `lab` exits non-zero when it detects an unrecognised global, and it was flagging `Symbol(undici.globalDispatcher.2)`.

This is Node.js's built-in undici (used by global `fetch`), not a project dependency. A Node/undici update bumped undici's internal global-dispatcher API version from `1` to `2`, so it now registers `Symbol(undici.globalDispatcher.2)` on `globalThis`. Our leak allowlist in .labrc.js only whitelisted `Symbol(undici.globalDispatcher.1)`, so the newer symbol was reported as a leak and failed the run.

### The fix

Added `Symbol(undici.globalDispatcher.2)` to the `globals` allowlist in .labrc.js, keeping `.1` in place for older Node versions. No application/test code changes were needed — the code was never at fault.

After the change, the full test suite passes with exit code `0`.